### PR TITLE
Stabilize CircleCI R dependency installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,14 @@ jobs:
           name: Install system tools
           command: |
             apt-get update -qq
-            apt-get install -y --no-install-recommends git openssh-client file qpdf
+            apt-get install -y --no-install-recommends git file qpdf
             rm -rf /var/lib/apt/lists/*
 
-      - checkout
+      - run:
+          name: Checkout code over HTTPS
+          command: |
+            git clone --depth=1 --branch "${CIRCLE_BRANCH}" "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git" .
+            git rev-parse --short HEAD
 
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,16 +27,7 @@ jobs:
       - run:
           name: Install R dependencies
           command: |
-            Rscript - <<'EOF'
-            options(repos = c(CRAN = "https://cloud.r-project.org"))
-
-            missing <- setdiff("remotes", rownames(installed.packages()))
-            if (length(missing) > 0) {
-              install.packages(missing)
-            }
-
-            remotes::install_deps(dependencies = TRUE, upgrade = "never")
-            EOF
+            Rscript -e 'options(repos = c(CRAN = "https://cloud.r-project.org")); if (!requireNamespace("remotes", quietly = TRUE)) install.packages("remotes"); remotes::install_deps(dependencies = TRUE, upgrade = "never")'
 
       - save_cache:
           key: deps-v3-{{ .Branch }}-{{ checksum "DESCRIPTION" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,29 +7,39 @@ jobs:
       - image: rocker/verse:4.4.3
     environment:
       R_KEEP_PKG_SOURCE: yes
+      NOT_CRAN: true
     steps:
       - run:
-          name: Install checkout tools
+          name: Install system tools
           command: |
             apt-get update -qq
-            apt-get install -y git openssh-client
+            apt-get install -y --no-install-recommends git openssh-client file qpdf
+            rm -rf /var/lib/apt/lists/*
 
       - checkout
 
       - restore_cache:
           keys:
-            - deps-v2-{{ .Branch }}-{{ checksum "DESCRIPTION" }}
-            - deps-v2-{{ .Branch }}-
-            - deps-v2-
+            - deps-v3-{{ .Branch }}-{{ checksum "DESCRIPTION" }}
+            - deps-v3-{{ .Branch }}-
+            - deps-v3-
 
       - run:
           name: Install R dependencies
           command: |
-            Rscript -e 'install.packages(c("devtools", "remotes"), repos = "https://cloud.r-project.org")'
-            Rscript -e 'devtools::install_deps(dependencies = TRUE, repos = "https://cloud.r-project.org")'
+            Rscript - <<'EOF'
+            options(repos = c(CRAN = "https://cloud.r-project.org"))
+
+            missing <- setdiff("remotes", rownames(installed.packages()))
+            if (length(missing) > 0) {
+              install.packages(missing)
+            }
+
+            remotes::install_deps(dependencies = TRUE, upgrade = "never")
+            EOF
 
       - save_cache:
-          key: deps-v2-{{ .Branch }}-{{ checksum "DESCRIPTION" }}
+          key: deps-v3-{{ .Branch }}-{{ checksum "DESCRIPTION" }}
           paths:
             - "/usr/local/lib/R/site-library"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,19 @@ jobs:
       NOT_CRAN: true
     steps:
       - run:
-          name: Install system tools
+          name: Install system tools and LaTeX
           command: |
             apt-get update -qq
-            apt-get install -y --no-install-recommends git file qpdf
+            apt-get install -y --no-install-recommends \
+              git \
+              file \
+              qpdf \
+              texlive-latex-base \
+              texlive-latex-recommended \
+              texlive-latex-extra \
+              texlive-fonts-recommended \
+              texlive-lang-portuguese \
+              latexmk
             rm -rf /var/lib/apt/lists/*
 
       - run:


### PR DESCRIPTION
## Resumo

- Substitui o `checkout` padrão do CircleCI por `git clone` via HTTPS.
- Isso evita o erro `git@github.com: Permission denied (publickey)` causado pela chave SSH de checkout do CircleCI.
- Instala ferramentas de sistema úteis aos testes (`git`, `file`, `qpdf`).
- Instala pacotes LaTeX necessários para os testes de PDF com `exams2pdf()`, incluindo `texlive-latex-base`, `texlive-latex-recommended`, `texlive-latex-extra`, `texlive-fonts-recommended`, `texlive-lang-portuguese` e `latexmk`.
- Troca a instalação pesada de `devtools` por `remotes::install_deps()`.
- Usa `upgrade = "never"` para evitar upgrades grandes e instáveis no CI.
- Bump do cache para `deps-v3` para evitar reaproveitamento de bibliotecas possivelmente inconsistentes.

## Contexto

O primeiro erro informado mostrava que o job falhava antes de instalar dependências ou rodar testes:

```text
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```

Como o repositório é público, clonar via HTTPS é suficiente e elimina a dependência da chave SSH de checkout do CircleCI.

Depois disso, o CI avançou para a etapa de testes e passou a falhar em `generate_pdf()` para muitas questões `.Rnw`. Como a falha ocorre em massa na geração de PDF, a causa provável é ausência de LaTeX/pacotes TeX no ambiente novo. Este PR agora instala explicitamente os pacotes TeX necessários antes de rodar os testes.