### PR TITLE
Add GitHub Actions R tests

### DIFF
--- a/.github/workflows/r-tests.yml
+++ b/.github/workflows/r-tests.yml
@@ -1,0 +1,59 @@
+name: R tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: r-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    env:
+      R_KEEP_PKG_SOURCE: yes
+      NOT_CRAN: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install system tools and LaTeX
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            file \
+            qpdf \
+            texlive-latex-base \
+            texlive-latex-recommended \
+            texlive-latex-extra \
+            texlive-fonts-recommended \
+            texlive-lang-portuguese \
+            latexmk
+          sudo rm -rf /var/lib/apt/lists/*
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: '4.4.3'
+          use-public-rspm: true
+
+      - name: Install R dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          cache-version: 1
+          dependencies: '"all"'
+
+      - name: Run BancoFisica tests
+        run: |
+          Rscript -e 'source("tests/tests.R")'


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow to run the BancoFisica R tests on pushes and pull requests to `master`.
- Set up R 4.4.3 with `r-lib/actions/setup-r`.
- Install R package dependencies from `DESCRIPTION` with `r-lib/actions/setup-r-dependencies`.
- Install the system tools and LaTeX packages needed by the current test suite, including `file`, `qpdf`, TeX Live packages and `latexmk`.
- Run the same command currently used in CircleCI: `Rscript -e 'source("tests/tests.R")'`.

## Notes

This PR intentionally keeps the existing CircleCI configuration in place. The goal is to validate GitHub Actions in parallel before removing CircleCI in a later PR.

## Test

GitHub Actions should run automatically for this pull request.