### PR TITLE
Audit solution blocks

### DIFF
--- a/.github/workflows/r-tests.yml
+++ b/.github/workflows/r-tests.yml
@@ -57,3 +57,7 @@ jobs:
       - name: Run BancoFisica tests
         run: |
           Rscript -e 'source("tests/tests.R")'
+
+      - name: Audit solution blocks
+        run: |
+          Rscript tools/audit_solutions.R

--- a/tools/audit_solutions.R
+++ b/tools/audit_solutions.R
@@ -1,5 +1,7 @@
 #!/usr/bin/env Rscript
 
+strict <- tolower(Sys.getenv("AUDIT_SOLUTIONS_STRICT", "false")) %in% c("1", "true", "yes")
+
 files <- sort(list.files("BancoDeQuestoes", pattern = "\\.[Rr]nw$", recursive = TRUE, full.names = TRUE))
 
 extract_solution <- function(txt) {
@@ -19,6 +21,13 @@ strip_noise <- function(x) {
   trimws(x)
 }
 
+add_problem <- function(report, file, problem) {
+  rbind(
+    report,
+    data.frame(file = file, problem = problem, stringsAsFactors = FALSE)
+  )
+}
+
 report <- data.frame(
   file = character(),
   problem = character(),
@@ -30,7 +39,7 @@ for (f in files) {
   sol <- extract_solution(txt)
 
   if (is.null(sol)) {
-    report <- rbind(report, data.frame(file = f, problem = "missing_solution_block"))
+    report <- add_problem(report, f, "missing_solution_block")
     next
   }
 
@@ -39,24 +48,33 @@ for (f in files) {
   clean_text <- paste(clean[nzchar(clean)], collapse = " ")
 
   if (grepl("Supply a solution here", sol_text, fixed = TRUE)) {
-    report <- rbind(report, data.frame(file = f, problem = "placeholder_solution"))
+    report <- add_problem(report, f, "placeholder_solution")
   }
 
   if (nchar(clean_text) < 20) {
-    report <- rbind(report, data.frame(file = f, problem = "very_short_solution"))
+    report <- add_problem(report, f, "very_short_solution")
   }
 }
 
 cat("Solution audit\n")
 cat("==============\n")
 cat("Total .Rnw files:", length(files), "\n")
-cat("Problematic entries:", nrow(report), "\n\n")
+cat("Problematic entries:", nrow(report), "\n")
+cat("Strict mode:", strict, "\n\n")
 
 if (nrow(report) > 0) {
   print(report, row.names = FALSE)
   cat("\nSummary by problem:\n")
   print(sort(table(report$problem), decreasing = TRUE))
-  quit(status = 1)
+
+  if (strict) {
+    cat("\nFailing because AUDIT_SOLUTIONS_STRICT is enabled.\n")
+    quit(status = 1)
+  }
+
+  cat("\nAudit found issues, but this run is non-blocking.\n")
+  cat("Set AUDIT_SOLUTIONS_STRICT=true to make these findings fail CI.\n")
+  quit(status = 0)
 }
 
 cat("All questions have non-trivial solution blocks.\n")

--- a/tools/audit_solutions.R
+++ b/tools/audit_solutions.R
@@ -1,0 +1,62 @@
+#!/usr/bin/env Rscript
+
+files <- sort(list.files("BancoDeQuestoes", pattern = "\\.[Rr]nw$", recursive = TRUE, full.names = TRUE))
+
+extract_solution <- function(txt) {
+  start <- grep("\\\\begin\\{solution\\}", txt)
+  end <- grep("\\\\end\\{solution\\}", txt)
+  if (length(start) == 0 || length(end) == 0) return(NULL)
+  end <- end[end > start[1]]
+  if (length(end) == 0) return(NULL)
+  txt[(start[1] + 1):(end[1] - 1)]
+}
+
+strip_noise <- function(x) {
+  x <- gsub("%%.*$", "", x)
+  x <- gsub("\\\\Sexpr\\{[^}]+\\}", "", x)
+  x <- gsub("\\\\begin\\{answerlist\\}|\\\\end\\{answerlist\\}|\\\\item", "", x)
+  x <- gsub("[$_{}\\\\]", " ", x)
+  trimws(x)
+}
+
+report <- data.frame(
+  file = character(),
+  problem = character(),
+  stringsAsFactors = FALSE
+)
+
+for (f in files) {
+  txt <- readLines(f, warn = FALSE, encoding = "UTF-8")
+  sol <- extract_solution(txt)
+
+  if (is.null(sol)) {
+    report <- rbind(report, data.frame(file = f, problem = "missing_solution_block"))
+    next
+  }
+
+  sol_text <- paste(sol, collapse = "\n")
+  clean <- strip_noise(sol)
+  clean_text <- paste(clean[nzchar(clean)], collapse = " ")
+
+  if (grepl("Supply a solution here", sol_text, fixed = TRUE)) {
+    report <- rbind(report, data.frame(file = f, problem = "placeholder_solution"))
+  }
+
+  if (nchar(clean_text) < 20) {
+    report <- rbind(report, data.frame(file = f, problem = "very_short_solution"))
+  }
+}
+
+cat("Solution audit\n")
+cat("==============\n")
+cat("Total .Rnw files:", length(files), "\n")
+cat("Problematic entries:", nrow(report), "\n\n")
+
+if (nrow(report) > 0) {
+  print(report, row.names = FALSE)
+  cat("\nSummary by problem:\n")
+  print(sort(table(report$problem), decreasing = TRUE))
+  quit(status = 1)
+}
+
+cat("All questions have non-trivial solution blocks.\n")


### PR DESCRIPTION
## Objetivo

Criar uma auditoria automática para verificar se as questões `.Rnw` possuem solucionário em LaTeX.

## O que este PR faz

- Adiciona `tools/audit_solutions.R`.
- O script varre todos os arquivos `.Rnw` em `BancoDeQuestoes`.
- Classifica problemas em três categorias:
  - `missing_solution_block`: não há bloco `\begin{solution}`/`\end{solution}`.
  - `placeholder_solution`: ainda há o comentário `Supply a solution here`.
  - `very_short_solution`: o bloco existe, mas parece conter só resposta curta ou quase nada.
- Roda a auditoria ao final do workflow `R tests` nesta branch.

## Observação

Este PR é intencionalmente de diagnóstico. A expectativa é que o CI liste os arquivos problemáticos; depois podemos abrir PRs por assunto adicionando os solucionários reais, sem tentar resolver centenas de questões em uma única mudança.