### PR TITLE
Limpa metadados e texto de questões

### DIFF
--- a/BancoDeQuestoes/eletromagnetismo/eletrostática/Q02Capacitores.Rnw
+++ b/BancoDeQuestoes/eletromagnetismo/eletrostática/Q02Capacitores.Rnw
@@ -1,6 +1,6 @@
 <<echo=FALSE, results=hide>>=
 ## FEITA POR Flavio Barros
-## Funcoes
+## Funções
 nota_cient <- function(x,digits) {
   if (x==0) return("0")
   ord <- floor(log(abs(x),10))
@@ -27,7 +27,7 @@ pega_int <- function(x, digits=NULL) {
   }
 }
 
-## Parametros
+## Parâmetros
 A = sample(50:80,1)
 d = round(runif(n = 1, min = 0.1, max = 0.9),1)
 rigidez = 4e7
@@ -56,17 +56,17 @@ include_supplement("Q02Capacitores.png")
 
 \begin{question}
 %% Enunciado
-Seja um capacitor de placas paralelas com a area das placas iguais a $A$ = \Sexpr{A} cm², separadas por uma distancia d = \Sexpr{d} mm uma da outra, e com uma pelicula de um dieletrico de nailon tambem com espessura d. Sabendo que a permissividade eletrica do vacuo e $\epsilon_0$ = $\Sexpr{nota_cient(epsilon0)}$ C²/N.m² e a constante dieletrica do nailon k = \Sexpr{k}, determine:
+Seja um capacitor de placas paralelas com a área das placas iguais a $A$ = \Sexpr{A} cm², separadas por uma distância d = \Sexpr{d} mm uma da outra, e com uma película de um dielétrico de náilon também com espessura d. Sabendo que a permissividade elétrica do vácuo é $\epsilon_0$ = $\Sexpr{nota_cient(epsilon0)}$ C²/N.m² e a constante dielétrica do náilon k = \Sexpr{k}, determine:
 
 \includegraphics[height = 7cm, keepaspectratio]{Q02Capacitores.png}
 
-(Dica: a rigidez dieletrica e a voltagem maxima que um metro de dieletrico suporta. Use essa informacao para descobrir a voltagem maxima do capacitor.)
+(Dica: a rigidez dielétrica é a voltagem máxima que um metro de dielétrico suporta. Use essa informação para descobrir a voltagem máxima do capacitor.)
 
 \begin{answerlist}
-  \item a permissividade eletrica do dieletrico. (Responda em pico = $10^{-12}$ e utilize dois algarismos significativos.)
+  \item a permissividade elétrica do dielétrico. (Responda em pico = $10^{-12}$ e utilize dois algarismos significativos.)
   \item a capacidade desse capacitor. (Responda em $nF$, ou nano Farads.)
-  \item a carga maxima que pode ser armazenada nesse capacitor, sabendo que a rigidez dieletrica do nailon e $\Sexpr{nota_cient(rigidez)}$ V/m. (Responda em $\mu C$)
-  \item A energia potencial acumulada no capacitor nas condicoes do item c. (Arredonde para uma decimal.)
+  \item a carga máxima que pode ser armazenada nesse capacitor, sabendo que a rigidez dielétrica do náilon é $\Sexpr{nota_cient(rigidez)}$ V/m. (Responda em $\mu C$)
+  \item A energia potencial acumulada no capacitor nas condições do item c. (Arredonde para uma decimal.)
 
 \end{answerlist}
 
@@ -77,9 +77,9 @@ Seja um capacitor de placas paralelas com a area das placas iguais a $A$ = \Sexp
 
 \begin{answerlist}
   \item $\Sexpr{epsilon_pico}$.
-  \item A capacitancia e $\Sexpr{C_nF}$nF.
-  \item A carga maxima e $\Sexpr{Qmax_uC}$ $\mu C$.
-  \item A energia e $\Sexpr{E}$J.
+  \item A capacitância é $\Sexpr{C_nF}$nF.
+  \item A carga máxima é $\Sexpr{Qmax_uC}$ $\mu C$.
+  \item A energia é $\Sexpr{E}$J.
 \end{answerlist}
 \end{solution}
 

--- a/BancoDeQuestoes/hidrostatica/Q09Empuxo.Rnw
+++ b/BancoDeQuestoes/hidrostatica/Q09Empuxo.Rnw
@@ -56,5 +56,5 @@ A tensão será \Sexpr{resp} N.
 %% META-INFORMATION
 %% \extype{num}
 %% \exsolution{\Sexpr{resp}}
-%% \exname{Q08Empuxo}
+%% \exname{Q09Empuxo}
 %% \extol{0.1}

--- a/BancoDeQuestoes/movcircular/Q01MCU.Rnw
+++ b/BancoDeQuestoes/movcircular/Q01MCU.Rnw
@@ -12,7 +12,7 @@ resp3 <- round(1/resp1, digits = 2)
 
 \begin{question}
 
-(MACK adapt.) Um automóvel, cujos pneus têm diâmetro externo de \Sexpr{diam} cm, percorre, com velocidade cosntante, \Sexpr{dist} metros em 1 minuto. Desprezando sua deformação, determine: (Adote $\pi = 3,14$)
+(MACK adapt.) Um automóvel, cujos pneus têm diâmetro externo de \Sexpr{diam} cm, percorre, com velocidade constante, \Sexpr{dist} metros em 1 minuto. Desprezando sua deformação, determine: (Adote $\pi = 3,14$)
 
 \begin{answerlist}
   \item A frequência do movimento de rotação dos pneus, em Hz. \textit{Dê sua resposta com duas decimais}
@@ -25,7 +25,7 @@ resp3 <- round(1/resp1, digits = 2)
 %% Solution
 
 \begin{answerlist}
-  \item $\Sexpr{resp1}$ hz
+  \item $\Sexpr{resp1}$ Hz
   \item $\Sexpr{resp2}$ voltas
   \item $\Sexpr{resp3}$ s
 \end{answerlist}


### PR DESCRIPTION
## Resumo

Aplica pequenas correções editoriais e de metadados em três questões.

## Alterações

- Q01MCU.Rnw: corrige a grafia de "constante" e troca "hz" por "Hz" na solução.
- Q02Capacitores.Rnw: restaura acentos e melhora a redação sem alterar o gabarito dinâmico corrigido anteriormente.
- Q09Empuxo.Rnw: corrige o metadado `exname` de `Q08Empuxo` para `Q09Empuxo`.

## Validação

A comparação com `master` mostra somente 3 arquivos Rnw alterados, com mudanças pequenas e localizadas.