### PR TITLE
Add ENEM central hydrostatics questions

### DIFF
--- a/BancoDeQuestoes/hidrostatica/Q92ClozeDensidadeProveta.Rnw
+++ b/BancoDeQuestoes/hidrostatica/Q92ClozeDensidadeProveta.Rnw
@@ -1,0 +1,56 @@
+<<echo=FALSE, results=hide>>=
+## Inspirada no ENEM 2020 Q113
+## Física central: densidade e volume deslocado em proveta.
+
+massa <- sample(seq(54, 162, by = 6), 1)
+rho <- sample(c(2.7, 3.0, 4.5, 5.4, 7.8, 8.9), 1)
+V0 <- sample(seq(30, 80, by = 5), 1)
+Vobj <- massa / rho
+Vf <- V0 + Vobj
+fmt <- function(x, d = 1) formatC(x, format = "f", digits = d, decimal.mark = ",")
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Um estudante deseja identificar um pequeno objeto metálico usando uma balança e uma proveta graduada. A massa medida foi $\Sexpr{massa}\,\mathrm{g}$. Ao mergulhar completamente o objeto na proveta, o nível da água passou de $\Sexpr{fmt(V0)}\,\mathrm{cm^3}$ para $\Sexpr{fmt(Vf)}\,\mathrm{cm^3}$.
+
+Determine:
+
+\begin{answerlist}
+  \item o volume do objeto, em $\mathrm{cm^3}$;
+  \item a densidade do objeto, em $\mathrm{g/cm^3}$.
+\end{answerlist}
+
+\end{question}
+
+\begin{solution}
+
+O volume do objeto é igual ao volume de água deslocado:
+\[
+V = V_f - V_0 = \Sexpr{fmt(Vf)} - \Sexpr{fmt(V0)} = \Sexpr{fmt(Vobj)}\,\mathrm{cm^3}.
+\]
+A densidade é dada por
+\[
+\rho = \frac{m}{V}.
+\]
+Assim,
+\[
+\rho = \frac{\Sexpr{massa}}{\Sexpr{fmt(Vobj)}} = \Sexpr{fmt(rho)}\,\mathrm{g/cm^3}.
+\]
+
+\begin{answerlist}
+  \item $\Sexpr{fmt(Vobj)}\,\mathrm{cm^3}$
+  \item $\Sexpr{fmt(rho)}\,\mathrm{g/cm^3}$
+\end{answerlist}
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{cloze}
+%% \exsolution{\Sexpr{round(Vobj, 2)}|\Sexpr{round(rho, 2)}}
+%% \exclozetype{num|num}
+%% \extol{0.05|0.05}
+%% \exname{Q92ClozeDensidadeProveta}
+%% \exsection{Hidrostatica; Densidade; ENEM}
+%% \exusepackage[utf8]{inputenc}

--- a/BancoDeQuestoes/hidrostatica/Q93QuizDensidadeFlutuacao.Rnw
+++ b/BancoDeQuestoes/hidrostatica/Q93QuizDensidadeFlutuacao.Rnw
@@ -1,0 +1,57 @@
+<<echo=FALSE, results=hide>>=
+## Inspirada no ENEM 2020 Q118
+## Física central: densidade e flutuação.
+
+rho_fluido <- sample(c(1.05, 1.10, 1.15, 1.20), 1)
+objetos <- c("A", "B", "C", "D", "E")
+rhos <- sample(c(0.82, 0.95, 1.00, 1.08, 1.12, 1.25, 1.35), 5)
+solutions <- rhos < rho_fluido
+if (sum(solutions) == 0 || sum(solutions) == 5) {
+  rhos <- c(0.90, 1.00, rho_fluido - 0.02, rho_fluido + 0.05, rho_fluido + 0.20)
+  solutions <- rhos < rho_fluido
+}
+fmt <- function(x, d = 2) formatC(x, format = "f", digits = d, decimal.mark = ",")
+linhas <- paste0(objetos, " & ", fmt(rhos), " \\\", collapse = "\n")
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Cinco pequenos corpos são colocados, separadamente, em um líquido de densidade $\Sexpr{fmt(rho_fluido)}\,\mathrm{g/cm^3}$. A tabela mostra as densidades dos corpos.
+
+\begin{center}
+\begin{tabular}{cc}
+Corpo & Densidade ($\mathrm{g/cm^3}$) \\
+\hline
+\Sexpr{linhas}
+\end{tabular}
+\end{center}
+
+Quais corpos tendem a flutuar nesse líquido?
+
+<<echo=FALSE, results=tex>>=
+answerlist(objetos)
+@
+
+\end{question}
+
+\begin{solution}
+
+Um corpo flutua quando sua densidade média é menor que a densidade do líquido:
+\[
+\rho_{\text{corpo}} < \rho_{\text{líquido}}.
+\]
+Neste caso, $\rho_{\text{líquido}} = \Sexpr{fmt(rho_fluido)}\,\mathrm{g/cm^3}$. Portanto, flutuam os corpos cuja densidade é menor que esse valor.
+
+<<echo=FALSE, results=tex>>=
+answerlist(ifelse(solutions, paste0("\\textbf{", objetos, "}"), objetos))
+@
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{mchoice}
+%% \exsolution{\Sexpr{mchoice2string(solutions)}}
+%% \exname{Q93QuizDensidadeFlutuacao}
+%% \exsection{Hidrostatica; Densidade; Flutuacao; ENEM}
+%% \exusepackage[utf8]{inputenc}

--- a/BancoDeQuestoes/hidrostatica/Q93QuizDensidadeFlutuacao.Rnw
+++ b/BancoDeQuestoes/hidrostatica/Q93QuizDensidadeFlutuacao.Rnw
@@ -11,7 +11,6 @@ if (sum(solutions) == 0 || sum(solutions) == 5) {
   solutions <- rhos < rho_fluido
 }
 fmt <- function(x, d = 2) formatC(x, format = "f", digits = d, decimal.mark = ",")
-linhas <- paste0(objetos, " & ", fmt(rhos), " \\\", collapse = "\n")
 @
 \usepackage[utf8]{inputenc}
 
@@ -23,7 +22,11 @@ Cinco pequenos corpos são colocados, separadamente, em um líquido de densidade
 \begin{tabular}{cc}
 Corpo & Densidade ($\mathrm{g/cm^3}$) \\
 \hline
-\Sexpr{linhas}
+A & \Sexpr{fmt(rhos[1])} \\
+B & \Sexpr{fmt(rhos[2])} \\
+C & \Sexpr{fmt(rhos[3])} \\
+D & \Sexpr{fmt(rhos[4])} \\
+E & \Sexpr{fmt(rhos[5])} \\
 \end{tabular}
 \end{center}
 

--- a/BancoDeQuestoes/hidrostatica/Q94ClozePressaoDescompressao.Rnw
+++ b/BancoDeQuestoes/hidrostatica/Q94ClozePressaoDescompressao.Rnw
@@ -1,0 +1,62 @@
+<<echo=FALSE, results=hide>>=
+## Inspirada no ENEM 2020 Q134
+## Física central: pressão hidrostática e descompressão.
+
+rho <- 1000
+prof <- sample(seq(10, 40, by = 5), 1)
+g <- 10
+pressao <- rho * g * prof
+pressao_atm <- 1e5
+pressao_total <- pressao_atm + pressao
+taxa <- sample(c(5000, 8000, 10000), 1)
+tempo <- pressao / taxa
+fmt <- function(x, d = 1) formatC(x, format = "f", digits = d, decimal.mark = ",")
+nota <- function(x) formatC(x, format = "f", digits = 0, big.mark = ".", decimal.mark = ",")
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Um mergulhador está a uma profundidade de $\Sexpr{prof}\,\mathrm{m}$ em água de densidade $1000\,\mathrm{kg/m^3}$. Adote $g = \Sexpr{g}\,\mathrm{m/s^2}$ e considere a pressão atmosférica igual a $100000\,\mathrm{Pa}$.
+
+Para reduzir riscos na subida, a variação de pressão suportada pelo mergulhador não deve ultrapassar $\Sexpr{nota(taxa)}\,\mathrm{Pa/s}$.
+
+Determine:
+
+\begin{answerlist}
+  \item a pressão hidrostática nessa profundidade, em Pa;
+  \item o menor tempo de subida, em segundos, para que a variação de pressão não ultrapasse o valor indicado.
+\end{answerlist}
+
+\end{question}
+
+\begin{solution}
+
+A pressão hidrostática é
+\[
+p_h = \rho g h.
+\]
+Assim,
+\[
+p_h = 1000 \cdot \Sexpr{g} \cdot \Sexpr{prof} = \Sexpr{nota(pressao)}\,\mathrm{Pa}.
+\]
+A pressão atmosférica se soma à pressão total, mas a variação de pressão na subida é a pressão hidrostática que deixa de atuar. Se a taxa máxima de variação é $\Sexpr{nota(taxa)}\,\mathrm{Pa/s}$, então
+\[
+\Delta t = \frac{\Delta p}{\text{taxa}} = \frac{\Sexpr{nota(pressao)}}{\Sexpr{nota(taxa)}} = \Sexpr{fmt(tempo)}\,\mathrm{s}.
+\]
+
+\begin{answerlist}
+  \item $\Sexpr{nota(pressao)}\,\mathrm{Pa}$
+  \item $\Sexpr{fmt(tempo)}\,\mathrm{s}$
+\end{answerlist}
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{cloze}
+%% \exsolution{\Sexpr{pressao}|\Sexpr{round(tempo, 2)}}
+%% \exclozetype{num|num}
+%% \extol{100|0.05}
+%% \exname{Q94ClozePressaoDescompressao}
+%% \exsection{Hidrostatica; Pressao; ENEM}
+%% \exusepackage[utf8]{inputenc}

--- a/BancoDeQuestoes/hidrostatica/Q95ClozeAlcoolometro.Rnw
+++ b/BancoDeQuestoes/hidrostatica/Q95ClozeAlcoolometro.Rnw
@@ -1,0 +1,56 @@
+<<echo=FALSE, results=hide>>=
+## Inspirada no ENEM 2021 Q93
+## Física central: densímetro, flutuação e correção térmica.
+
+leitura <- sample(seq(90, 98, by = 1), 1)
+T <- sample(c(12, 14, 18, 22, 24, 28), 1)
+correcao <- round((20 - T) * 0.25, 1)
+corrigida <- leitura + correcao
+fmt <- function(x, d = 1) formatC(x, format = "f", digits = d, decimal.mark = ",")
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Um alcoômetro foi calibrado para fornecer a leitura correta a $20\,^{\circ}\mathrm{C}$. Em uma medida feita a $\Sexpr{T}\,^{\circ}\mathrm{C}$, a leitura aparente foi $\Sexpr{leitura}\,^{\circ}\mathrm{GL}$. Para o instrumento utilizado, a correção aproximada é de $0{,}25\,^{\circ}\mathrm{GL}$ por grau Celsius de diferença em relação a $20\,^{\circ}\mathrm{C}$, somando-se a correção quando a temperatura é menor que $20\,^{\circ}\mathrm{C}$ e subtraindo-se quando é maior.
+
+Determine:
+
+\begin{answerlist}
+  \item a correção, em $^{\circ}\mathrm{GL}$, com sinal;
+  \item a leitura corrigida, em $^{\circ}\mathrm{GL}$.
+\end{answerlist}
+
+\end{question}
+
+\begin{solution}
+
+A correção é proporcional à diferença entre a temperatura de calibração e a temperatura da medida:
+\[
+C = (20 - T)\cdot 0{,}25.
+\]
+Logo,
+\[
+C = (20 - \Sexpr{T})\cdot 0{,}25 = \Sexpr{fmt(correcao)}\,^{\circ}\mathrm{GL}.
+\]
+A leitura corrigida é
+\[
+L_c = L + C = \Sexpr{leitura} + \Sexpr{fmt(correcao)} = \Sexpr{fmt(corrigida)}\,^{\circ}\mathrm{GL}.
+\]
+Fisicamente, essa correção está associada ao fato de que a densidade do líquido varia com a temperatura, alterando a flutuação do densímetro.
+
+\begin{answerlist}
+  \item $\Sexpr{fmt(correcao)}\,^{\circ}\mathrm{GL}$
+  \item $\Sexpr{fmt(corrigida)}\,^{\circ}\mathrm{GL}$
+\end{answerlist}
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{cloze}
+%% \exsolution{\Sexpr{round(correcao, 2)}|\Sexpr{round(corrigida, 2)}}
+%% \exclozetype{num|num}
+%% \extol{0.05|0.05}
+%% \exname{Q95ClozeAlcoolometro}
+%% \exsection{Hidrostatica; Densimetro; ENEM}
+%% \exusepackage[utf8]{inputenc}

--- a/BancoDeQuestoes/hidrostatica/Q96ClozePressaoColuna.Rnw
+++ b/BancoDeQuestoes/hidrostatica/Q96ClozePressaoColuna.Rnw
@@ -1,0 +1,47 @@
+<<echo=FALSE, results=hide>>=
+## Inspirada no ENEM 2025 Q124
+## Física central: pressão exercida por coluna de material.
+
+rho <- sample(c(600, 700, 800, 900, 1000), 1)
+g <- 10
+pmax_kpa <- sample(c(12, 15, 18, 20, 24, 30), 1)
+pmax <- pmax_kpa * 1000
+hmax <- pmax / (rho * g)
+fmt <- function(x, d = 1) formatC(x, format = "f", digits = d, decimal.mark = ",")
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Uma laje suporta pressão máxima de $\Sexpr{pmax_kpa}\,\mathrm{kPa}$. Sobre ela será depositado um material granulado de densidade média $\Sexpr{rho}\,\mathrm{kg/m^3}$, formando uma camada uniforme. Adote $g = \Sexpr{g}\,\mathrm{m/s^2}$.
+
+Qual é a altura máxima da camada de material para que a pressão sobre a laje não ultrapasse o limite? Responda em metros.
+
+\end{question}
+
+\begin{solution}
+
+A pressão exercida por uma coluna de material pode ser estimada por
+\[
+p = \rho g h.
+\]
+Isolando a altura,
+\[
+h = \frac{p}{\rho g}.
+\]
+Como $\Sexpr{pmax_kpa}\,\mathrm{kPa}=\Sexpr{pmax}\,\mathrm{Pa}$,
+\[
+h = \frac{\Sexpr{pmax}}{\Sexpr{rho}\cdot \Sexpr{g}} = \Sexpr{fmt(hmax)}\,\mathrm{m}.
+\]
+
+Portanto, a altura máxima é $\Sexpr{fmt(hmax)}\,\mathrm{m}$.
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{num}
+%% \exsolution{\Sexpr{round(hmax, 2)}}
+%% \extol{0.05}
+%% \exname{Q96ClozePressaoColuna}
+%% \exsection{Hidrostatica; Pressao; ENEM}
+%% \exusepackage[utf8]{inputenc}

--- a/BancoDeQuestoes/hidrostatica/Q97ClozePressaoEscala.Rnw
+++ b/BancoDeQuestoes/hidrostatica/Q97ClozePressaoEscala.Rnw
@@ -1,0 +1,58 @@
+<<echo=FALSE, results=hide>>=
+## Inspirada no ENEM 2020 Q135
+## Física central: pressão e escala dimensional.
+
+f <- sample(c(2, 3, 4, 5, 6), 1)
+razao_area <- f^2
+razao_volume <- f^3
+razao_pressao <- f
+fmt <- function(x) formatC(x, format = "f", digits = 0, big.mark = ".", decimal.mark = ",")
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Considere dois modelos geometricamente semelhantes de uma mesma estrutura. O segundo modelo tem todas as dimensões lineares $\Sexpr{f}$ vezes maiores que as do primeiro. Suponha que o material seja o mesmo, de modo que o peso seja proporcional ao volume, e que a área de apoio seja proporcional à área da base.
+
+Determine:
+
+\begin{answerlist}
+  \item por qual fator a área de apoio aumenta;
+  \item por qual fator o peso aumenta;
+  \item por qual fator a pressão sobre o solo aumenta.
+\end{answerlist}
+
+\end{question}
+
+\begin{solution}
+
+Se todas as dimensões lineares são multiplicadas por $\Sexpr{f}$, então as áreas são multiplicadas por $\Sexpr{f}^2$ e os volumes por $\Sexpr{f}^3$.
+
+Assim,
+\[
+A' = \Sexpr{f}^2 A = \Sexpr{razao_area}A,
+\]
+\[
+P' = \Sexpr{f}^3 P = \Sexpr{razao_volume}P.
+\]
+A pressão é força dividida por área. Logo,
+\[
+\frac{p'}{p}=\frac{\Sexpr{razao_volume}}{\Sexpr{razao_area}}=\Sexpr{razao_pressao}.
+\]
+
+\begin{answerlist}
+  \item $\Sexpr{razao_area}$
+  \item $\Sexpr{razao_volume}$
+  \item $\Sexpr{razao_pressao}$
+\end{answerlist}
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{cloze}
+%% \exsolution{\Sexpr{razao_area}|\Sexpr{razao_volume}|\Sexpr{razao_pressao}}
+%% \exclozetype{num|num|num}
+%% \extol{0.01|0.01|0.01}
+%% \exname{Q97ClozePressaoEscala}
+%% \exsection{Hidrostatica; Pressao; Escala; ENEM}
+%% \exusepackage[utf8]{inputenc}

--- a/BancoDeQuestoes/hidrostatica/Q98QuizEmpuxoDensidade.Rnw
+++ b/BancoDeQuestoes/hidrostatica/Q98QuizEmpuxoDensidade.Rnw
@@ -1,0 +1,70 @@
+<<echo=FALSE, results=hide>>=
+## Questão de revisão do lote ENEM Física Central: empuxo e densidade.
+## Adaptada para consolidar a ideia de que flutuação depende da densidade média.
+
+rho_liq <- sample(c(0.90, 1.00, 1.10, 1.20), 1)
+rho_obj <- sample(c(0.70, 0.80, 0.95, 1.05, 1.30), 1)
+flutua <- rho_obj < rho_liq
+fmt <- function(x, d = 2) formatC(x, format = "f", digits = d, decimal.mark = ",")
+questions <- c(
+  paste0("O corpo flutua, pois sua densidade média é menor que a do líquido."),
+  paste0("O corpo afunda, pois sua densidade média é menor que a do líquido."),
+  paste0("O corpo flutua necessariamente, pois todo sólido flutua em líquidos."),
+  paste0("O corpo afunda necessariamente, pois o empuxo é sempre menor que o peso."),
+  paste0("A flutuação não depende da densidade média do corpo.")
+)
+solutions <- c(flutua, FALSE, FALSE, FALSE, FALSE)
+if (!flutua) {
+  questions[1] <- "O corpo flutua, pois sua densidade média é menor que a do líquido."
+  questions[2] <- "O corpo afunda, pois sua densidade média é maior que a do líquido."
+  solutions <- c(FALSE, TRUE, FALSE, FALSE, FALSE)
+}
+ordem <- sample(1:5)
+questions <- questions[ordem]
+solutions <- solutions[ordem]
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Um corpo de densidade média $\Sexpr{fmt(rho_obj)}\,\mathrm{g/cm^3}$ é colocado em um líquido de densidade $\Sexpr{fmt(rho_liq)}\,\mathrm{g/cm^3}$.
+
+Qual afirmação descreve corretamente o comportamento inicial do corpo?
+
+<<echo=FALSE, results=tex>>=
+answerlist(questions)
+@
+
+\end{question}
+
+\begin{solution}
+
+A comparação relevante é entre a densidade média do corpo e a densidade do líquido. Se
+\[
+\rho_{\text{corpo}} < \rho_{\text{líquido}},
+\]
+o corpo tende a flutuar. Se
+\[
+\rho_{\text{corpo}} > \rho_{\text{líquido}},
+\]
+o corpo tende a afundar.
+
+Neste caso,
+\[
+\rho_{\text{corpo}} = \Sexpr{fmt(rho_obj)}\,\mathrm{g/cm^3}
+\quad\text{e}\quad
+\rho_{\text{líquido}} = \Sexpr{fmt(rho_liq)}\,\mathrm{g/cm^3}.
+\]
+
+<<echo=FALSE, results=tex>>=
+answerlist(ifelse(solutions, paste0("\\textbf{", questions, "}"), questions))
+@
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{schoice}
+%% \exsolution{\Sexpr{mchoice2string(solutions, single = TRUE)}}
+%% \exname{Q98QuizEmpuxoDensidade}
+%% \exsection{Hidrostatica; Empuxo; Densidade; ENEM}
+%% \exusepackage[utf8]{inputenc}


### PR DESCRIPTION
## Resumo

Adiciona um primeiro lote de questões de Física Central do ENEM, focado em Hidrostática.

Este PR foi separado do lote maior Mecânica + Hidrostática para reduzir risco de falha e facilitar revisão. O lote de Mecânica ficará para o próximo PR.

## Questões adicionadas

- `BancoDeQuestoes/hidrostatica/Q92ClozeDensidadeProveta.Rnw`
  - Inspirada no ENEM 2020 Q113
  - Densidade e volume deslocado em proveta
  - Tipo: `cloze`
  - Coleta: volume deslocado e densidade

- `BancoDeQuestoes/hidrostatica/Q93QuizDensidadeFlutuacao.Rnw`
  - Inspirada no ENEM 2020 Q118
  - Densidade e flutuação
  - Tipo: `mchoice`
  - Coleta: seleção de todos os corpos que flutuam

- `BancoDeQuestoes/hidrostatica/Q94ClozePressaoDescompressao.Rnw`
  - Inspirada no ENEM 2020 Q134
  - Pressão hidrostática e descompressão
  - Tipo: `cloze`
  - Coleta: pressão hidrostática e tempo mínimo de subida

- `BancoDeQuestoes/hidrostatica/Q95ClozeAlcoolometro.Rnw`
  - Inspirada no ENEM 2021 Q93
  - Densímetro/alcoômetro e correção térmica
  - Tipo: `cloze`
  - Coleta: correção e leitura corrigida

- `BancoDeQuestoes/hidrostatica/Q96ClozePressaoColuna.Rnw`
  - Inspirada no ENEM 2025 Q124
  - Pressão máxima e coluna de material
  - Tipo: `num`
  - Coleta: altura máxima

- `BancoDeQuestoes/hidrostatica/Q97ClozePressaoEscala.Rnw`
  - Inspirada no ENEM 2020 Q135
  - Pressão e escala dimensional
  - Tipo: `cloze`
  - Coleta: fator de área, fator de peso e fator de pressão

- `BancoDeQuestoes/hidrostatica/Q98QuizEmpuxoDensidade.Rnw`
  - Questão de consolidação do lote, sobre empuxo e densidade média
  - Tipo: `schoice`

## Imagens

Este lote não usa imagens originais do ENEM nem figuras externas. As questões foram estruturadas com tabelas e enunciados parametrizados. Figuras originais do ENEM ficam reservadas para os casos esquemáticos complexos em PRs posteriores.

## Escopo técnico

- Não altera README.
- Não altera CircleCI.
- Não altera `docs/question-counts.csv` nem `docs/question-counts.svg`.
- Cada questão contém solucionário em LaTeX.
- O workflow do GitHub Actions deve validar XML, PDF, geração local do gráfico em `build/` e auditoria de solucionários.

## Observação

Não consegui rodar `Rscript` localmente neste ambiente; a validação principal é o GitHub Actions.