### PR TITLE
Adicionar vitrine pública inicial do BancoFisica

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -1,0 +1,359 @@
+:root {
+  --bg: #f6f8fb;
+  --surface: #ffffff;
+  --surface-soft: #eef4ff;
+  --text: #172033;
+  --muted: #5d6880;
+  --line: #d9e1ef;
+  --primary: #1d4ed8;
+  --primary-dark: #173ea9;
+  --accent: #0f766e;
+  --shadow: 0 18px 45px rgba(23, 32, 51, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+}
+
+.container {
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(255, 255, 255, 0.92);
+  border-bottom: 1px solid var(--line);
+  backdrop-filter: blur(16px);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 68px;
+  gap: 1rem;
+}
+
+.brand {
+  font-weight: 800;
+  font-size: 1.25rem;
+  text-decoration: none;
+  letter-spacing: -0.03em;
+}
+
+.nav-links {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.nav-links a {
+  color: var(--muted);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.nav-links a:hover,
+.nav-links a[aria-current="page"] {
+  color: var(--primary);
+}
+
+.hero {
+  padding: 5rem 0 4rem;
+  background:
+    radial-gradient(circle at top left, rgba(29, 78, 216, 0.16), transparent 34rem),
+    linear-gradient(180deg, #ffffff 0%, var(--bg) 100%);
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(280px, 0.7fr);
+  gap: 2rem;
+  align-items: center;
+}
+
+.hero h1,
+.section-heading h1,
+.section-heading h2 {
+  margin: 0;
+  line-height: 1.08;
+  letter-spacing: -0.05em;
+}
+
+.hero h1 {
+  max-width: 760px;
+  font-size: clamp(2.5rem, 7vw, 5rem);
+}
+
+.lead {
+  max-width: 720px;
+  margin: 1.5rem 0 0;
+  color: var(--muted);
+  font-size: 1.2rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--accent);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.11em;
+  font-size: 0.78rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.85rem;
+  flex-wrap: wrap;
+  margin-top: 2rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0.7rem 1rem;
+  border-radius: 999px;
+  font-weight: 800;
+  text-decoration: none;
+  border: 1px solid transparent;
+}
+
+.button.primary {
+  color: white;
+  background: var(--primary);
+}
+
+.button.primary:hover {
+  background: var(--primary-dark);
+}
+
+.button.secondary {
+  color: var(--primary);
+  background: white;
+  border-color: var(--line);
+}
+
+.hero-card,
+.card,
+.notice,
+.question-card,
+.filters {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  box-shadow: var(--shadow);
+}
+
+.hero-card {
+  padding: 1.5rem;
+}
+
+.hero-card h2 {
+  margin-top: 0;
+}
+
+.section {
+  padding: 4rem 0;
+}
+
+.section-heading {
+  margin-bottom: 1.5rem;
+}
+
+.section-heading.narrow {
+  max-width: 760px;
+}
+
+.section-heading h1,
+.section-heading h2 {
+  font-size: clamp(2rem, 4vw, 3.4rem);
+}
+
+.section-heading p,
+.split p {
+  color: var(--muted);
+  font-size: 1.06rem;
+}
+
+.cards {
+  display: grid;
+  gap: 1rem;
+}
+
+.three-columns {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.card {
+  padding: 1.4rem;
+}
+
+.card h3 {
+  margin-top: 0;
+}
+
+.card p {
+  margin-bottom: 0;
+  color: var(--muted);
+}
+
+.split {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(260px, 0.8fr);
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.notice {
+  padding: 1.25rem;
+  background: var(--surface-soft);
+}
+
+.filters {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr 1fr;
+  gap: 1rem;
+  padding: 1rem;
+  margin: 1.5rem 0;
+}
+
+.filters label {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--muted);
+  font-weight: 700;
+}
+
+input,
+select {
+  width: 100%;
+  min-height: 42px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 0.65rem 0.75rem;
+  color: var(--text);
+  background: white;
+  font: inherit;
+}
+
+.catalog-status {
+  color: var(--muted);
+  font-weight: 700;
+}
+
+.question-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.question-card {
+  padding: 1.25rem;
+}
+
+.question-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.question-card h2 {
+  margin: 0.15rem 0 0;
+  font-size: 1.35rem;
+}
+
+.question-id,
+.question-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.badge,
+.tag {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.24rem 0.65rem;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.badge {
+  color: #075985;
+  background: #e0f2fe;
+}
+
+.tags {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  margin: 0.9rem 0;
+}
+
+.tag {
+  color: #334155;
+  background: #f1f5f9;
+}
+
+details {
+  margin-top: 0.75rem;
+  border-top: 1px solid var(--line);
+  padding-top: 0.75rem;
+}
+
+summary {
+  cursor: pointer;
+  font-weight: 800;
+  color: var(--primary);
+}
+
+.question-body,
+.solution-body {
+  margin-top: 0.85rem;
+  color: var(--text);
+}
+
+.question-body ol {
+  padding-left: 1.4rem;
+}
+
+.footer {
+  border-top: 1px solid var(--line);
+  padding: 1.5rem 0;
+  color: var(--muted);
+  background: white;
+}
+
+@media (max-width: 800px) {
+  .hero-grid,
+  .three-columns,
+  .split,
+  .filters {
+    grid-template-columns: 1fr;
+  }
+
+  .nav {
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 1rem 0;
+  }
+}

--- a/site/data/questoes-demo.json
+++ b/site/data/questoes-demo.json
@@ -1,0 +1,42 @@
+{
+  "metadata": {
+    "project": "BancoFisica",
+    "description": "Dados públicos usados apenas na vitrine demonstrativa do site.",
+    "visibilityPolicy": "Somente questões com visibility=demo devem ser publicadas no site."
+  },
+  "questions": [
+    {
+      "id": "DEMO-MEC-001",
+      "title": "Velocidade média em um trajeto retilíneo",
+      "area": "Mecânica",
+      "subject": "Cinemática",
+      "level": "Ensino Médio",
+      "visibility": "demo",
+      "tags": ["velocidade média", "unidades", "moodle"],
+      "statementHtml": "<p>Um estudante percorre uma distância de \\(120\\,\\text{m}\\) em \\(30\\,\\text{s}\\), mantendo movimento retilíneo. Qual é a velocidade média nesse trecho?</p><ol type=\"A\"><li>\\(2\\,\\text{m/s}\\)</li><li>\\(4\\,\\text{m/s}\\)</li><li>\\(30\\,\\text{m/s}\\)</li><li>\\(150\\,\\text{m/s}\\)</li></ol>",
+      "solutionHtml": "<p>A velocidade média é dada por \\(v_m = \\Delta s / \\Delta t\\). Portanto, \\(v_m = 120/30 = 4\\,\\text{m/s}\\). A alternativa correta é B.</p>"
+    },
+    {
+      "id": "DEMO-TER-001",
+      "title": "Conversão de temperatura",
+      "area": "Termologia",
+      "subject": "Temperatura",
+      "level": "Ensino Médio",
+      "visibility": "demo",
+      "tags": ["temperatura", "Celsius", "Kelvin"],
+      "statementHtml": "<p>Em uma atividade de laboratório, a temperatura de uma amostra é medida como \\(27\\,^{\\circ}\\text{C}\\). Qual é o valor aproximado dessa temperatura na escala Kelvin?</p><ol type=\"A\"><li>\\(27\\,\\text{K}\\)</li><li>\\(100\\,\\text{K}\\)</li><li>\\(246\\,\\text{K}\\)</li><li>\\(300\\,\\text{K}\\)</li></ol>",
+      "solutionHtml": "<p>Para converter Celsius em Kelvin, usamos \\(T_K = T_C + 273\\). Assim, \\(T_K = 27 + 273 = 300\\,\\text{K}\\). A alternativa correta é D.</p>"
+    },
+    {
+      "id": "DEMO-ELE-001",
+      "title": "Lei de Ohm em um resistor",
+      "area": "Eletromagnetismo",
+      "subject": "Circuitos elétricos",
+      "level": "Ensino Médio",
+      "visibility": "demo",
+      "tags": ["lei de Ohm", "resistência elétrica", "corrente elétrica"],
+      "statementHtml": "<p>Um resistor de resistência \\(6\\,\\Omega\\) é submetido a uma diferença de potencial de \\(12\\,\\text{V}\\). Qual é a corrente elétrica que atravessa o resistor?</p><ol type=\"A\"><li>\\(0{,}5\\,\\text{A}\\)</li><li>\\(2\\,\\text{A}\\)</li><li>\\(6\\,\\text{A}\\)</li><li>\\(72\\,\\text{A}\\)</li></ol>",
+      "solutionHtml": "<p>Pela lei de Ohm, \\(U = R i\\). Logo, \\(i = U/R = 12/6 = 2\\,\\text{A}\\). A alternativa correta é B.</p>"
+    }
+  ]
+}

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="BancoFisica: banco aberto de questões parametrizadas de Física para Moodle e ensino."
+    />
+    <title>BancoFisica</title>
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav container" aria-label="Navegação principal">
+        <a class="brand" href="index.html">BancoFisica</a>
+        <div class="nav-links">
+          <a href="questoes.html">Questões demonstrativas</a>
+          <a href="https://github.com/IFSP-HTO/BancoFisica">GitHub</a>
+        </div>
+      </nav>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="container hero-grid">
+          <div>
+            <p class="eyebrow">Projeto aberto do IFSP Câmpus Hortolândia</p>
+            <h1>Questões parametrizadas de Física para ensino, avaliação e Moodle.</h1>
+            <p class="lead">
+              O BancoFisica reúne questões de Física programadas em R com o pacote
+              <strong>exams</strong>, permitindo gerar variações, exportar para Moodle
+              e documentar o processo de criação de itens avaliativos.
+            </p>
+            <div class="actions">
+              <a class="button primary" href="questoes.html">Ver demonstrações</a>
+              <a class="button secondary" href="https://github.com/IFSP-HTO/BancoFisica">Abrir repositório</a>
+            </div>
+          </div>
+          <aside class="hero-card" aria-label="Resumo do projeto">
+            <h2>Vitrine pública</h2>
+            <p>
+              Este site apresenta somente questões demonstrativas e documentação geral.
+              O banco completo usado em avaliações não é exposto nesta vitrine.
+            </p>
+          </aside>
+        </div>
+      </section>
+
+      <section class="container section">
+        <div class="section-heading">
+          <p class="eyebrow">Por que existe?</p>
+          <h2>Um banco para reduzir retrabalho e aumentar qualidade</h2>
+        </div>
+        <div class="cards three-columns">
+          <article class="card">
+            <h3>Parametrização</h3>
+            <p>
+              Uma mesma questão pode gerar várias versões numéricas, ajudando a criar
+              listas, questionários e avaliações com menor repetição.
+            </p>
+          </article>
+          <article class="card">
+            <h3>Integração com Moodle</h3>
+            <p>
+              O projeto usa o ecossistema R/exams para gerar arquivos compatíveis com
+              ambientes virtuais de aprendizagem, incluindo Moodle.
+            </p>
+          </article>
+          <article class="card">
+            <h3>Rigor e colaboração</h3>
+            <p>
+              As questões podem ser revisadas, testadas e aprimoradas por meio de pull
+              requests, com solucionários e validações no repositório.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="container section split">
+        <div>
+          <p class="eyebrow">Segurança avaliativa</p>
+          <h2>Questões reais preservadas</h2>
+          <p>
+            Como o BancoFisica pode ser usado em avaliações, a vitrine pública não
+            pretende listar o banco completo. A página de demonstrações mostra exemplos
+            autorais e sacrificáveis, criados para explicar o funcionamento do projeto.
+          </p>
+        </div>
+        <div class="notice">
+          <strong>Regra do site:</strong>
+          publicar apenas itens marcados como demonstrativos ou criados especificamente
+          para divulgação.
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="container">
+        <p>
+          BancoFisica — questões de Física em R/exams para ensino e Moodle.
+        </p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -1,0 +1,156 @@
+const state = {
+  questions: [],
+  search: '',
+  area: '',
+  subject: ''
+};
+
+const elements = {
+  search: document.querySelector('#search'),
+  areaFilter: document.querySelector('#area-filter'),
+  subjectFilter: document.querySelector('#subject-filter'),
+  count: document.querySelector('#count'),
+  catalog: document.querySelector('#catalog'),
+  template: document.querySelector('#question-template')
+};
+
+async function loadQuestions() {
+  try {
+    const response = await fetch('data/questoes-demo.json');
+    if (!response.ok) {
+      throw new Error(`Erro ao carregar dados: ${response.status}`);
+    }
+
+    const data = await response.json();
+    state.questions = data.questions.filter((question) => question.visibility === 'demo');
+    setupFilters();
+    render();
+  } catch (error) {
+    elements.catalog.innerHTML = `
+      <article class="question-card">
+        <h2>Não foi possível carregar o catálogo</h2>
+        <p>${escapeHtml(error.message)}</p>
+      </article>
+    `;
+  }
+}
+
+function setupFilters() {
+  const areas = uniqueSorted(state.questions.map((question) => question.area));
+  const subjects = uniqueSorted(state.questions.map((question) => question.subject));
+
+  fillSelect(elements.areaFilter, areas, 'Todas');
+  fillSelect(elements.subjectFilter, subjects, 'Todos');
+
+  elements.search.addEventListener('input', (event) => {
+    state.search = event.target.value.trim().toLowerCase();
+    render();
+  });
+
+  elements.areaFilter.addEventListener('change', (event) => {
+    state.area = event.target.value;
+    render();
+  });
+
+  elements.subjectFilter.addEventListener('change', (event) => {
+    state.subject = event.target.value;
+    render();
+  });
+}
+
+function fillSelect(select, values, defaultLabel) {
+  select.innerHTML = `<option value="">${defaultLabel}</option>`;
+  values.forEach((value) => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = value;
+    select.appendChild(option);
+  });
+}
+
+function render() {
+  const filtered = state.questions.filter(matchesFilters);
+  elements.count.textContent = `${filtered.length} de ${state.questions.length} questões demonstrativas`;
+
+  elements.catalog.innerHTML = '';
+
+  if (filtered.length === 0) {
+    elements.catalog.innerHTML = `
+      <article class="question-card">
+        <h2>Nenhuma questão encontrada</h2>
+        <p>Experimente remover algum filtro ou alterar o termo de busca.</p>
+      </article>
+    `;
+    return;
+  }
+
+  filtered.forEach((question) => {
+    elements.catalog.appendChild(renderQuestion(question));
+  });
+
+  if (window.MathJax?.typesetPromise) {
+    window.MathJax.typesetPromise();
+  }
+}
+
+function matchesFilters(question) {
+  const haystack = [
+    question.id,
+    question.title,
+    question.area,
+    question.subject,
+    question.level,
+    ...(question.tags || [])
+  ]
+    .join(' ')
+    .toLowerCase();
+
+  return (
+    (!state.search || haystack.includes(state.search)) &&
+    (!state.area || question.area === state.area) &&
+    (!state.subject || question.subject === state.subject)
+  );
+}
+
+function renderQuestion(question) {
+  const fragment = elements.template.content.cloneNode(true);
+  const card = fragment.querySelector('.question-card');
+  const title = fragment.querySelector('h2');
+  const id = fragment.querySelector('.question-id');
+  const meta = fragment.querySelector('.question-meta');
+  const tags = fragment.querySelector('.tags');
+  const body = fragment.querySelector('.question-body');
+  const solution = fragment.querySelector('.solution-body');
+
+  card.dataset.area = question.area;
+  card.dataset.subject = question.subject;
+  title.textContent = question.title;
+  id.textContent = question.id;
+  meta.textContent = `${question.area} · ${question.subject} · ${question.level}`;
+  body.innerHTML = question.statementHtml;
+  solution.innerHTML = question.solutionHtml;
+
+  (question.tags || []).forEach((tag) => {
+    const item = document.createElement('span');
+    item.className = 'tag';
+    item.textContent = tag;
+    tags.appendChild(item);
+  });
+
+  return fragment;
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values.filter(Boolean))].sort((a, b) => a.localeCompare(b, 'pt-BR'));
+}
+
+function escapeHtml(value) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
+
+loadQuestions();

--- a/site/questoes.html
+++ b/site/questoes.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Questões demonstrativas do BancoFisica com filtros por área e assunto."
+    />
+    <title>Questões demonstrativas | BancoFisica</title>
+    <link rel="stylesheet" href="css/style.css" />
+    <script>
+      window.MathJax = {
+        tex: { inlineMath: [['\\(', '\\)'], ['$', '$']] },
+        svg: { fontCache: 'global' }
+      };
+    </script>
+    <script defer src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"></script>
+    <script defer src="js/app.js"></script>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav container" aria-label="Navegação principal">
+        <a class="brand" href="index.html">BancoFisica</a>
+        <div class="nav-links">
+          <a href="questoes.html" aria-current="page">Questões demonstrativas</a>
+          <a href="https://github.com/IFSP-HTO/BancoFisica">GitHub</a>
+        </div>
+      </nav>
+    </header>
+
+    <main class="container section">
+      <div class="section-heading narrow">
+        <p class="eyebrow">Catálogo público</p>
+        <h1>Questões demonstrativas</h1>
+        <p>
+          Esta página mostra apenas itens de demonstração. Ela existe para divulgar o
+          formato do BancoFisica sem expor o banco completo usado em avaliações.
+        </p>
+      </div>
+
+      <section class="filters" aria-label="Filtros do catálogo">
+        <label>
+          Busca
+          <input id="search" type="search" placeholder="Buscar por título, assunto ou tag" />
+        </label>
+        <label>
+          Área
+          <select id="area-filter">
+            <option value="">Todas</option>
+          </select>
+        </label>
+        <label>
+          Assunto
+          <select id="subject-filter">
+            <option value="">Todos</option>
+          </select>
+        </label>
+      </section>
+
+      <section class="catalog-status" aria-live="polite">
+        <p id="count"></p>
+      </section>
+
+      <section id="catalog" class="question-list" aria-label="Lista de questões"></section>
+    </main>
+
+    <template id="question-template">
+      <article class="question-card">
+        <div class="question-header">
+          <div>
+            <p class="question-id"></p>
+            <h2></h2>
+          </div>
+          <span class="badge">Demonstração</span>
+        </div>
+        <p class="question-meta"></p>
+        <div class="tags"></div>
+        <details>
+          <summary>Ver enunciado</summary>
+          <div class="question-body"></div>
+        </details>
+        <details>
+          <summary>Ver solução demonstrativa</summary>
+          <div class="solution-body"></div>
+        </details>
+      </article>
+    </template>
+
+    <footer class="footer">
+      <div class="container">
+        <p>
+          BancoFisica — vitrine pública com questões demonstrativas.
+        </p>
+      </div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Resumo

Este PR adiciona uma primeira versão estática do site público do BancoFisica em `site/`.

A proposta é criar uma vitrine pública simples, usando HTML, CSS e JavaScript puro, sem ainda configurar o deploy via GitHub Pages neste PR.

## O que foi incluído

- `site/index.html`: página inicial institucional do BancoFisica.
- `site/questoes.html`: catálogo público de questões demonstrativas.
- `site/css/style.css`: estilos responsivos para a vitrine.
- `site/js/app.js`: carregamento do catálogo, filtros e renderização das questões.
- `site/data/questoes-demo.json`: dados demonstrativos autorais, com `visibility=demo`.

## Decisão estratégica

O site publica apenas questões demonstrativas, preservando o banco completo usado em avaliações.

## Fora do escopo deste PR

- Configuração do GitHub Pages.
- Workflow de deploy.
- Geração automática do JSON a partir das questões reais.
- Preview Moodle completo.

Esses pontos devem entrar em PRs posteriores.