### PR TITLE
Melhora solucionários de questões antigas - lote 1

### DIFF
--- a/BancoDeQuestoes/acel/Q01Acel.Rnw
+++ b/BancoDeQuestoes/acel/Q01Acel.Rnw
@@ -15,9 +15,24 @@ Determine o módulo da aceleração em $m/s^2$.
 \end{question}
 
 %% SOLUTION
-\begin{solution}:
+\begin{solution}
 
-  \Sexpr{resp}
+Primeiro convertemos a velocidade inicial para o Sistema Internacional:
+\[
+  v_0 = \frac{\Sexpr{v}}{3{,}6}=\Sexpr{round(v/3.6, 2)}\,\mathrm{m/s}.
+\]
+
+Como o automóvel para, sua velocidade final é $v=0$. O módulo da aceleração média em um movimento com aceleração constante é
+\[
+  |a| = \frac{|\Delta v|}{\Delta t}.
+\]
+
+Assim,
+\[
+  |a| = \frac{\Sexpr{round(v/3.6, 2)}}{5}=\Sexpr{resp}\,\mathrm{m/s^2}.
+\]
+
+Portanto, o módulo da aceleração é $\Sexpr{resp}\,\mathrm{m/s^2}$.
   
 \end{solution}
 
@@ -26,4 +41,3 @@ Determine o módulo da aceleração em $m/s^2$.
 %% \exsolution{\Sexpr{resp}}
 %% \exname{Q01Acel.Rnw}
 %% \extol{0.1}
-

--- a/BancoDeQuestoes/calorimetria/Q04CalS.Rnw
+++ b/BancoDeQuestoes/calorimetria/Q04CalS.Rnw
@@ -2,7 +2,7 @@
 #Marcelo C.
 
 Q <- sample(seq(from=2000, to=7500, by=100), 1)
-resp1 = Q/40
+resp1 = Q/50
 resp2 = resp1/200
 @
 \usepackage[utf8]{inputenc}
@@ -21,14 +21,28 @@ Um corpo de 200 g é aquecido de 20 °C para 70 °C ao receber \Sexpr{Q} cal. De
 
 %% SOLUTION
 \begin{solution}
-  
-  \begin{answerlist}
 
-    \item \Sexpr{resp1}
-  
-    \item \Sexpr{resp2}
-  
-  \end{answerlist}
+A variação de temperatura é
+\[
+  \Delta T = 70 - 20 = 50\,^{\circ}\mathrm{C}.
+\]
+
+A capacidade térmica $C$ indica quanto calor o corpo recebe para cada grau Celsius de variação de temperatura:
+\[
+  C = \frac{Q}{\Delta T}=\frac{\Sexpr{Q}}{50}=\Sexpr{resp1}\,\mathrm{cal/^{\circ}C}.
+\]
+
+O calor específico sensível $c$ é a capacidade térmica por unidade de massa:
+\[
+  c = \frac{C}{m}=\frac{\Sexpr{resp1}}{200}=\Sexpr{resp2}\,\mathrm{cal/(g\,^{\circ}C)}.
+\]
+
+Portanto:
+\begin{answerlist}
+  \item a capacidade térmica é $\Sexpr{resp1}\,\mathrm{cal/^{\circ}C}$;
+  \item o calor específico sensível é $\Sexpr{resp2}\,\mathrm{cal/(g\,^{\circ}C)}$.
+\end{answerlist}
+
 \end{solution}
 
 %% META-INFORMATION

--- a/BancoDeQuestoes/calorimetria/Q52MaqTerm.Rnw
+++ b/BancoDeQuestoes/calorimetria/Q52MaqTerm.Rnw
@@ -5,7 +5,7 @@
   
   q2     <- sample(seq(from=50,to=190,by=1),1)
   
-  resp1  <- round((1-(q2)/(q1)), digits = 1)
+  resp1  <- round((1-(q2)/(q1)), digits = 2)
     
 @
   
@@ -18,9 +18,26 @@ Uma máquina térmica que retira de uma fonte quente $\Sexpr{q1}$ cal e passa pa
 \end{question}
   
 %% SOLUTION
-\begin{solution}:
-    
-  \Sexpr{resp1}
+\begin{solution}
+
+O rendimento de uma máquina térmica é a razão entre o trabalho útil produzido e o calor retirado da fonte quente:
+\[
+  \eta = \frac{W}{Q_q}.
+\]
+
+Como a máquina recebe $Q_q=\Sexpr{q1}\,\mathrm{cal}$ da fonte quente e rejeita $Q_f=\Sexpr{q2}\,\mathrm{cal}$ para a fonte fria, o trabalho útil é
+\[
+  W = Q_q - Q_f = \Sexpr{q1} - \Sexpr{q2} = \Sexpr{q1-q2}\,\mathrm{cal}.
+\]
+
+Logo,
+\[
+  \eta = \frac{\Sexpr{q1-q2}}{\Sexpr{q1}}
+       = 1 - \frac{\Sexpr{q2}}{\Sexpr{q1}}
+       = \Sexpr{resp1}.
+\]
+
+Portanto, o rendimento da máquina é $\Sexpr{resp1}$, ou aproximadamente $\Sexpr{round(100*resp1, 0)}\%$.
   
 \end{solution}
   

--- a/BancoDeQuestoes/cinematica/MU/Q05MU.Rnw
+++ b/BancoDeQuestoes/cinematica/MU/Q05MU.Rnw
@@ -7,24 +7,25 @@ d2 <- df-d1
 v1 <- sample(seq(from=90,to=120,by=2),1)
 v2 <- sample(seq(from=40,to=60,by=2),1)
 
-resp <- (d1/v1)+(d2/v2)
-resp1 <- resp
+t1 <- d1/v1
+t2 <- d2/v2
+resp_total <- t1 + t2
 
 questions <- solutions <- rep("", 3)
 type <- rep(c("schoice"), 3)
 
 questions[1] <- ""
-solutions[1] <- floor(resp)
+solutions[1] <- floor(resp_total)
 type[1] <- "num"
 
 questions[2] <- ""
-solutions[2] <- floor((resp - floor(resp)) * 60)
+solutions[2] <- floor((resp_total - floor(resp_total)) * 60)
 type[2] <- "num"
 
-resp <- (resp - floor(resp)) * 60
+resp_min <- (resp_total - floor(resp_total)) * 60
 
 questions[3] <- ""
-solutions[3] <- round((resp - floor(resp)) * 60)
+solutions[3] <- round((resp_min - floor(resp_min)) * 60)
 type[3] <- "num"
 
 options(OutDec=",")
@@ -47,8 +48,31 @@ answerlist(questions)
 \end{question}
 
 %% SOLUTION
-\begin{solution}:
-  
+\begin{solution}
+
+O tempo em cada trecho é obtido pela relação
+\[
+  t=\frac{\Delta s}{v}.
+\]
+
+No primeiro trecho,
+\[
+  t_1=\frac{\Sexpr{d1}}{\Sexpr{v1}}=\Sexpr{round(t1, 4)}\,\mathrm{h}.
+\]
+No segundo trecho,
+\[
+  t_2=\frac{\Sexpr{d2}}{\Sexpr{v2}}=\Sexpr{round(t2, 4)}\,\mathrm{h}.
+\]
+
+O tempo total é
+\[
+  t=t_1+t_2=\Sexpr{round(resp_total, 4)}\,\mathrm{h}.
+\]
+
+Separando a parte inteira, obtemos $\Sexpr{solutions[1]}$ hora(s). A parte decimal restante é convertida para minutos, multiplicando por 60; isso fornece $\Sexpr{solutions[2]}$ minuto(s). A parte decimal dos minutos é novamente multiplicada por 60, resultando em $\Sexpr{solutions[3]}$ segundo(s).
+
+Portanto, o tempo total de viagem é:
+
 <<echo=FALSE, results=hide, results=tex>>=
 answerlist(paste(solutions, ".", sep = ""))
 @

--- a/BancoDeQuestoes/estatica/Q20estce.Rnw
+++ b/BancoDeQuestoes/estatica/Q20estce.Rnw
@@ -21,8 +21,31 @@ include_supplement("Q20estce.jpg")
 \end{question}
 
 \begin{solution}
-%% Supply a solution here!
-  \Sexpr{resp} N
+
+Para eliminar as forças desconhecidas na articulação em A, calculamos os torques em relação ao ponto A.
+
+Pela figura, o peso da barra homogênea atua em seu centro, a 4 m de A, e a carga atua na extremidade B, a 8 m de A. A componente vertical da tração no cabo é responsável pelo torque que equilibra esses pesos. Pelo triângulo geométrico do cabo, essa componente vale
+\[
+  T_y = 0{,}6T.
+\]
+
+No equilíbrio de rotação,
+\[
+  T_y\cdot 8 = P_{\text{barra}}\cdot 4 + P_{\text{carga}}\cdot 8.
+\]
+
+Substituindo $T_y=0{,}6T$ e os valores do enunciado,
+\[
+  0{,}6T\cdot 8 = \Sexpr{pa}\cdot 4 + \Sexpr{fa}\cdot 8.
+\]
+
+Logo,
+\[
+  T = \frac{\Sexpr{pa}\cdot 4 + \Sexpr{fa}\cdot 8}{4{,}8}
+    = \Sexpr{resp}\,\mathrm{N}.
+\]
+
+Portanto, a tração no cabo é $\Sexpr{resp}\,\mathrm{N}$.
 
 \end{solution}
 

--- a/BancoDeQuestoes/trabalhopotencia/Q04Trab.Rnw
+++ b/BancoDeQuestoes/trabalhopotencia/Q04Trab.Rnw
@@ -11,14 +11,27 @@ resp <- round(m*10*h)
 
 \begin{question}
 
-(PUC-RJ-adapt. Um atleta de salto em altura, de \Sexpr{m} kg, atingiu a altura de \Sexpr{h} m, aterrissando a 3 m do seu ponto inicial. Determine o trabalho realizado pelo peso durante a sua descida. Adote g = 10 m/s².
+(PUC-RJ-adapt.) Um atleta de salto em altura, de \Sexpr{m} kg, atingiu a altura de \Sexpr{h} m, aterrissando a 3 m do seu ponto inicial. Determine o trabalho realizado pelo peso durante a sua descida. Adote g = 10 m/s².
 
 \end{question}
 
 %% SOLUTION
-\begin{solution}:
+\begin{solution}
 
-  \Sexpr{resp} J
+Durante a descida, a força peso tem o mesmo sentido do deslocamento vertical do atleta. Por isso, o trabalho realizado pelo peso é positivo.
+
+O trabalho da força peso depende apenas da variação de altura, não da distância horizontal percorrida. Assim,
+\[
+  W_P = mgh.
+\]
+
+Substituindo os valores:
+\[
+  W_P = \Sexpr{m}\cdot 10 \cdot \Sexpr{h}
+      = \Sexpr{resp}\,\mathrm{J}.
+\]
+
+Portanto, o trabalho realizado pelo peso durante a descida é $\Sexpr{resp}\,\mathrm{J}$.
 
 \end{solution}
 


### PR DESCRIPTION
## Resumo

Melhora o solucionário de seis questões antigas que tinham solução muito curta, normalmente apenas a resposta numérica.

## Critério usado

Usei o critério já presente em `tools/audit_solutions.R`, que identifica blocos de solução ausentes, placeholders (`Supply a solution here`) e soluções muito curtas (`very_short_solution`).

## Questões atualizadas

- `BancoDeQuestoes/acel/Q01Acel.Rnw`
  - Explica conversão de km/h para m/s.
  - Explica o cálculo do módulo da aceleração durante a frenagem.

- `BancoDeQuestoes/calorimetria/Q04CalS.Rnw`
  - Explica capacidade térmica e calor específico.
  - Corrige o uso de `ΔT`: o enunciado vai de 20 °C a 70 °C, portanto `ΔT = 50 °C`, não 40 °C.

- `BancoDeQuestoes/calorimetria/Q52MaqTerm.Rnw`
  - Explica rendimento de máquina térmica a partir de `η = W/Q_q`.
  - Explicita `W = Q_q - Q_f`.
  - Arredonda o rendimento com duas casas decimais, compatível com `extol{0.01}`.

- `BancoDeQuestoes/cinematica/MU/Q05MU.Rnw`
  - Explica o cálculo do tempo em cada trecho.
  - Explica a conversão da parte decimal de horas para minutos e segundos.

- `BancoDeQuestoes/estatica/Q20estce.Rnw`
  - Substitui placeholder por solução de equilíbrio de torques.
  - Explica a escolha do ponto A e a componente vertical da tração.

- `BancoDeQuestoes/trabalhopotencia/Q04Trab.Rnw`
  - Explica trabalho da força peso durante a descida.
  - Esclarece que a distância horizontal não entra no cálculo do trabalho do peso.

## Observações

Este é um primeiro lote deliberadamente pequeno. A ideia é seguir em PRs sucessivos por assunto, para facilitar revisão e reduzir risco de alterar muitas questões de uma vez.

## Testes

Não executei os testes localmente nesta interface. O PR deve ser validado pelo workflow de R tests.