### PR TITLE
Melhora solucionários de densidade e capacitores - lote 2

### DIFF
--- a/BancoDeQuestoes/eletromagnetismo/eletrostática/Q01Capacitores.Rnw
+++ b/BancoDeQuestoes/eletromagnetismo/eletrostática/Q01Capacitores.Rnw
@@ -7,7 +7,7 @@ nota_cient <- function(x,digits) {
   x <- x / 10^ord
   if (!missing(digits)) x <- format(x,digits=digits)
   if (ord==0) return(as.character(x))
-  return(paste(x,"\\\\times 10^{",ord,"}",sep=""))
+  return(paste(x,"\\times 10^{",ord,"}",sep=""))
 }
 formatEng <- function(x, fixed=NULL) {
   s <-as.numeric(strsplit(format(x, scientific=T),"e")[[1]])
@@ -83,16 +83,74 @@ Sabendo que o potencial elétrico resultante dessas esferas é nulo no ponto M d
 \end{question}
 
 \begin{solution}
-%% Supply a solution here!
 
+No ponto M, o potencial elétrico resultante é nulo. Como $AM=2\,MB$, podemos escrever
+\[
+  V_M = k\frac{Q_A}{AM}+k\frac{Q_B}{MB}=0.
+\]
+Tomando $MB=x$ e $AM=2x$,
+\[
+  k\frac{Q_A}{2x}+k\frac{Q_B}{x}=0.
+\]
+Cancelando $k$ e $x$,
+\[
+  \frac{Q_A}{2}+Q_B=0
+  \quad\Rightarrow\quad
+  Q_B=-\frac{Q_A}{2}.
+\]
+Assim,
+\[
+  Q_B=-\frac{\Sexpr{nota_cient(QA)}}{2}=\Sexpr{QB_uC}\,\mu\mathrm{C}.
+\]
+
+A capacitância de uma esfera condutora isolada é
+\[
+  C=\frac{r}{k},
+\]
+com o raio em metros. Portanto,
+\[
+  C_A=\frac{\Sexpr{ra}\times 10^{-2}}{\Sexpr{nota_cient(k)}}
+  =\Sexpr{nota_cient(CA)}\,\mathrm{F}
+  =\Sexpr{CA_pF}\,\mathrm{pF},
+\]
+e
+\[
+  C_B=\frac{\Sexpr{rb}\times 10^{-2}}{\Sexpr{nota_cient(k)}}
+  =\Sexpr{nota_cient(CB)}\,\mathrm{F}
+  =\Sexpr{CB_pF}\,\mathrm{pF}.
+\]
+
+Ao ligar as esferas por um fio condutor, elas ficam no mesmo potencial elétrico:
+\[
+  \frac{Q'_A}{C_A}=\frac{Q'_B}{C_B}.
+\]
+Além disso, a carga total se conserva:
+\[
+  Q'_A+Q'_B=Q_A+Q_B.
+\]
+Usando essas duas relações, obtemos as cargas finais
+\[
+  Q'_A=\Sexpr{QA_cond_uC}\,\mu\mathrm{C}
+  \quad\text{e}\quad
+  Q'_B=\Sexpr{QB_cond_uC}\,\mu\mathrm{C}.
+\]
+
+O potencial final de cada esfera é calculado por $V=Q/C$. Como as esferas estão ligadas por um fio condutor, os potenciais devem ser iguais, a menos de diferenças de arredondamento:
+\[
+  V_A=\frac{Q'_A}{C_A}=\Sexpr{PA}\,\mathrm{V},
+  \qquad
+  V_B=\frac{Q'_B}{C_B}=\Sexpr{PB}\,\mathrm{V}.
+\]
+
+Portanto:
 \begin{answerlist}
-  \item A carga da esfera B é $\Sexpr{QB_uC}$$\mu C$.
-  \item A capacitância da esfera A é $\Sexpr{CA_pF}$$pF$.
-  \item A capacitância da esfera B é $\Sexpr{CB_pF}$$pF$.
-  \item A carga da esfera A depois de ligá-las a um fio condutor é $\Sexpr{QA_cond_uC}$$\mu C$.
-  \item A carga da esfera B depois de ligá-las a um fio condutor é $\Sexpr{QB_cond_uC}$$\mu C$.
-  \item O potencial elétrico da esfera A é $\Sexpr{PA}V$ (Utilize os valores arredondados das respostas anteriores.)
-  \item O potencial elétrico da esfera B é $\Sexpr{PB}V$ (Utilize os valores arredondados das respostas anteriores.)
+  \item A carga da esfera B é $\Sexpr{QB_uC}\,\mu\mathrm{C}$.
+  \item A capacitância da esfera A é $\Sexpr{CA_pF}\,\mathrm{pF}$.
+  \item A capacitância da esfera B é $\Sexpr{CB_pF}\,\mathrm{pF}$.
+  \item A carga da esfera A depois de ligá-las a um fio condutor é $\Sexpr{QA_cond_uC}\,\mu\mathrm{C}$.
+  \item A carga da esfera B depois de ligá-las a um fio condutor é $\Sexpr{QB_cond_uC}\,\mu\mathrm{C}$.
+  \item O potencial elétrico da esfera A é $\Sexpr{PA}\,\mathrm{V}$.
+  \item O potencial elétrico da esfera B é $\Sexpr{PB}\,\mathrm{V}$.
 \end{answerlist}
 \end{solution}
 

--- a/BancoDeQuestoes/eletromagnetismo/eletrostática/Q01Capacitores.Rnw
+++ b/BancoDeQuestoes/eletromagnetismo/eletrostática/Q01Capacitores.Rnw
@@ -7,7 +7,7 @@ nota_cient <- function(x,digits) {
   x <- x / 10^ord
   if (!missing(digits)) x <- format(x,digits=digits)
   if (ord==0) return(as.character(x))
-  return(paste(x,"\\times 10^{",ord,"}",sep=""))
+  return(paste(x,"\\\\times 10^{",ord,"}",sep=""))
 }
 formatEng <- function(x, fixed=NULL) {
   s <-as.numeric(strsplit(format(x, scientific=T),"e")[[1]])
@@ -131,7 +131,7 @@ Além disso, a carga total se conserva:
 Usando essas duas relações, obtemos as cargas finais
 \[
   Q'_A=\Sexpr{QA_cond_uC}\,\mu\mathrm{C}
-  \quad\text{e}\quad
+  \quad\mathrm{e}\quad
   Q'_B=\Sexpr{QB_cond_uC}\,\mu\mathrm{C}.
 \]
 

--- a/BancoDeQuestoes/eletromagnetismo/eletrostática/Q01Capacitores.Rnw
+++ b/BancoDeQuestoes/eletromagnetismo/eletrostática/Q01Capacitores.Rnw
@@ -83,74 +83,16 @@ Sabendo que o potencial elétrico resultante dessas esferas é nulo no ponto M d
 \end{question}
 
 \begin{solution}
+%% Supply a solution here!
 
-No ponto M, o potencial elétrico resultante é nulo. Como $AM=2\,MB$, podemos escrever
-\[
-  V_M = k\frac{Q_A}{AM}+k\frac{Q_B}{MB}=0.
-\]
-Tomando $MB=x$ e $AM=2x$,
-\[
-  k\frac{Q_A}{2x}+k\frac{Q_B}{x}=0.
-\]
-Cancelando $k$ e $x$,
-\[
-  \frac{Q_A}{2}+Q_B=0
-  \quad\Rightarrow\quad
-  Q_B=-\frac{Q_A}{2}.
-\]
-Assim,
-\[
-  Q_B=-\frac{\Sexpr{nota_cient(QA)}}{2}=\Sexpr{QB_uC}\,\mu\mathrm{C}.
-\]
-
-A capacitância de uma esfera condutora isolada é
-\[
-  C=\frac{r}{k},
-\]
-com o raio em metros. Portanto,
-\[
-  C_A=\frac{\Sexpr{ra}\times 10^{-2}}{\Sexpr{nota_cient(k)}}
-  =\Sexpr{nota_cient(CA)}\,\mathrm{F}
-  =\Sexpr{CA_pF}\,\mathrm{pF},
-\]
-e
-\[
-  C_B=\frac{\Sexpr{rb}\times 10^{-2}}{\Sexpr{nota_cient(k)}}
-  =\Sexpr{nota_cient(CB)}\,\mathrm{F}
-  =\Sexpr{CB_pF}\,\mathrm{pF}.
-\]
-
-Ao ligar as esferas por um fio condutor, elas ficam no mesmo potencial elétrico:
-\[
-  \frac{Q'_A}{C_A}=\frac{Q'_B}{C_B}.
-\]
-Além disso, a carga total se conserva:
-\[
-  Q'_A+Q'_B=Q_A+Q_B.
-\]
-Usando essas duas relações, obtemos as cargas finais
-\[
-  Q'_A=\Sexpr{QA_cond_uC}\,\mu\mathrm{C}
-  \quad\mathrm{e}\quad
-  Q'_B=\Sexpr{QB_cond_uC}\,\mu\mathrm{C}.
-\]
-
-O potencial final de cada esfera é calculado por $V=Q/C$. Como as esferas estão ligadas por um fio condutor, os potenciais devem ser iguais, a menos de diferenças de arredondamento:
-\[
-  V_A=\frac{Q'_A}{C_A}=\Sexpr{PA}\,\mathrm{V},
-  \qquad
-  V_B=\frac{Q'_B}{C_B}=\Sexpr{PB}\,\mathrm{V}.
-\]
-
-Portanto:
 \begin{answerlist}
-  \item A carga da esfera B é $\Sexpr{QB_uC}\,\mu\mathrm{C}$.
-  \item A capacitância da esfera A é $\Sexpr{CA_pF}\,\mathrm{pF}$.
-  \item A capacitância da esfera B é $\Sexpr{CB_pF}\,\mathrm{pF}$.
-  \item A carga da esfera A depois de ligá-las a um fio condutor é $\Sexpr{QA_cond_uC}\,\mu\mathrm{C}$.
-  \item A carga da esfera B depois de ligá-las a um fio condutor é $\Sexpr{QB_cond_uC}\,\mu\mathrm{C}$.
-  \item O potencial elétrico da esfera A é $\Sexpr{PA}\,\mathrm{V}$.
-  \item O potencial elétrico da esfera B é $\Sexpr{PB}\,\mathrm{V}$.
+  \item A carga da esfera B é $\Sexpr{QB_uC}$$\mu C$.
+  \item A capacitância da esfera A é $\Sexpr{CA_pF}$$pF$.
+  \item A capacitância da esfera B é $\Sexpr{CB_pF}$$pF$.
+  \item A carga da esfera A depois de ligá-las a um fio condutor é $\Sexpr{QA_cond_uC}$$\mu C$.
+  \item A carga da esfera B depois de ligá-las a um fio condutor é $\Sexpr{QB_cond_uC}$$\mu C$.
+  \item O potencial elétrico da esfera A é $\Sexpr{PA}V$ (Utilize os valores arredondados das respostas anteriores.)
+  \item O potencial elétrico da esfera B é $\Sexpr{PB}V$ (Utilize os valores arredondados das respostas anteriores.)
 \end{answerlist}
 \end{solution}
 

--- a/BancoDeQuestoes/eletromagnetismo/eletrostática/Q02Capacitores.Rnw
+++ b/BancoDeQuestoes/eletromagnetismo/eletrostática/Q02Capacitores.Rnw
@@ -3,11 +3,11 @@
 ## Funções
 nota_cient <- function(x,digits) {
   if (x==0) return("0")
-  ord <- floor(log(abs(x),10))
+  ord <- floor(log(abs(x,10)))
   x <- x / 10^ord
   if (!missing(digits)) x <- format(x,digits=digits)
   if (ord==0) return(as.character(x))
-  return(paste(x,"\\\\times 10^{",ord,"}",sep=""))
+  return(paste(x,"\\times 10^{",ord,"}",sep=""))
 }
 formatEng <- function(x, fixed=NULL) {
   s <-as.numeric(strsplit(format(x, scientific=T),"e")[[1]])
@@ -73,13 +73,57 @@ Seja um capacitor de placas paralelas com a área das placas iguais a $A$ = \Sex
 \end{question}
 
 \begin{solution}
-%% Supply a solution here!
 
+A permissividade elétrica do dielétrico é dada por
+\[
+  \epsilon = k\epsilon_0.
+\]
+Logo,
+\[
+  \epsilon = \Sexpr{k}\cdot \Sexpr{nota_cient(epsilon0)}
+  = \Sexpr{nota_cient(epsilon)}\,\mathrm{C^2/(N\,m^2)}.
+\]
+Em unidades de $10^{-12}$, isso corresponde a $\Sexpr{epsilon_pico}$.
+
+Para um capacitor de placas paralelas,
+\[
+  C=\frac{\epsilon A}{d}.
+\]
+Antes de substituir, convertemos as unidades: $\Sexpr{A}\,\mathrm{cm^2}=\Sexpr{A}\times 10^{-4}\,\mathrm{m^2}$ e $\Sexpr{d}\,\mathrm{mm}=\Sexpr{d}\times 10^{-3}\,\mathrm{m}$. Assim,
+\[
+  C=\frac{\Sexpr{nota_cient(epsilon)}\cdot \Sexpr{A}\times 10^{-4}}{\Sexpr{d}\times 10^{-3}}
+  = \Sexpr{nota_cient(C)}\,\mathrm{F}.
+\]
+Em nanofarads, isso corresponde a $\Sexpr{C_nF}\,\mathrm{nF}$.
+
+A tensão máxima é obtida pela rigidez dielétrica:
+\[
+  \Delta V_{\max}=E_{\max}d
+  = \Sexpr{nota_cient(rigidez)}\cdot \Sexpr{d}\times 10^{-3}
+  = \Sexpr{deltaV}\,\mathrm{V}.
+\]
+
+A carga máxima é
+\[
+  Q_{\max}=C\Delta V_{\max}
+  = \Sexpr{nota_cient(C)}\cdot \Sexpr{deltaV}
+  = \Sexpr{nota_cient(Qmax)}\,\mathrm{C},
+\]
+ou seja, $\Sexpr{Qmax_uC}\,\mu\mathrm{C}$.
+
+A energia armazenada no capacitor é
+\[
+  U=\frac{Q_{\max}\Delta V_{\max}}{2}
+  =\frac{\Sexpr{nota_cient(Qmax)}\cdot \Sexpr{deltaV}}{2}
+  =\Sexpr{E}\,\mathrm{J}.
+\]
+
+Portanto:
 \begin{answerlist}
   \item $\Sexpr{epsilon_pico}$.
-  \item A capacitância é $\Sexpr{C_nF}$nF.
-  \item A carga máxima é $\Sexpr{Qmax_uC}$ $\mu C$.
-  \item A energia é $\Sexpr{E}$J.
+  \item A capacitância é $\Sexpr{C_nF}\,\mathrm{nF}$.
+  \item A carga máxima é $\Sexpr{Qmax_uC}\,\mu\mathrm{C}$.
+  \item A energia é $\Sexpr{E}\,\mathrm{J}$.
 \end{answerlist}
 \end{solution}
 

--- a/BancoDeQuestoes/eletromagnetismo/eletrostática/Q02Capacitores.Rnw
+++ b/BancoDeQuestoes/eletromagnetismo/eletrostática/Q02Capacitores.Rnw
@@ -7,7 +7,7 @@ nota_cient <- function(x,digits) {
   x <- x / 10^ord
   if (!missing(digits)) x <- format(x,digits=digits)
   if (ord==0) return(as.character(x))
-  return(paste(x,"\\times 10^{",ord,"}",sep=""))
+  return(paste(x,"\\\\times 10^{",ord,"}",sep=""))
 }
 formatEng <- function(x, fixed=NULL) {
   s <-as.numeric(strsplit(format(x, scientific=T),"e")[[1]])

--- a/BancoDeQuestoes/eletromagnetismo/eletrostática/Q02Capacitores.Rnw
+++ b/BancoDeQuestoes/eletromagnetismo/eletrostática/Q02Capacitores.Rnw
@@ -3,7 +3,7 @@
 ## Funções
 nota_cient <- function(x,digits) {
   if (x==0) return("0")
-  ord <- floor(log(abs(x,10)))
+  ord <- floor(log(abs(x),10))
   x <- x / 10^ord
   if (!missing(digits)) x <- format(x,digits=digits)
   if (ord==0) return(as.character(x))

--- a/BancoDeQuestoes/eletromagnetismo/eletrostática/Q02Capacitores.Rnw
+++ b/BancoDeQuestoes/eletromagnetismo/eletrostática/Q02Capacitores.Rnw
@@ -73,57 +73,19 @@ Seja um capacitor de placas paralelas com a área das placas iguais a $A$ = \Sex
 \end{question}
 
 \begin{solution}
+A permissividade do dielétrico é $k\epsilon_0$, resultando em \Sexpr{epsilon_pico} na unidade pedida.
 
-A permissividade elétrica do dielétrico é dada por
-\[
-  \epsilon = k\epsilon_0.
-\]
-Logo,
-\[
-  \epsilon = \Sexpr{k}\cdot \Sexpr{nota_cient(epsilon0)}
-  = \Sexpr{nota_cient(epsilon)}\,\mathrm{C^2/(N\,m^2)}.
-\]
-Em unidades de $10^{-12}$, isso corresponde a $\Sexpr{epsilon_pico}$.
+A capacitância é calculada por $C=\epsilon A/d$, convertendo a área para m² e a distância para m. O resultado é \Sexpr{C_nF} nF.
 
-Para um capacitor de placas paralelas,
-\[
-  C=\frac{\epsilon A}{d}.
-\]
-Antes de substituir, convertemos as unidades: $\Sexpr{A}\,\mathrm{cm^2}=\Sexpr{A}\times 10^{-4}\,\mathrm{m^2}$ e $\Sexpr{d}\,\mathrm{mm}=\Sexpr{d}\times 10^{-3}\,\mathrm{m}$. Assim,
-\[
-  C=\frac{\Sexpr{nota_cient(epsilon)}\cdot \Sexpr{A}\times 10^{-4}}{\Sexpr{d}\times 10^{-3}}
-  = \Sexpr{nota_cient(C)}\,\mathrm{F}.
-\]
-Em nanofarads, isso corresponde a $\Sexpr{C_nF}\,\mathrm{nF}$.
+A tensão máxima vem da rigidez dielétrica multiplicada pela distância entre as placas. Com essa tensão, a carga máxima é $Q=C\Delta V$, resultando em \Sexpr{Qmax_uC} $\mu C$.
 
-A tensão máxima é obtida pela rigidez dielétrica:
-\[
-  \Delta V_{\max}=E_{\max}d
-  = \Sexpr{nota_cient(rigidez)}\cdot \Sexpr{d}\times 10^{-3}
-  = \Sexpr{deltaV}\,\mathrm{V}.
-\]
+Por fim, a energia armazenada é calculada por $U=Q\Delta V/2$, resultando em \Sexpr{E} J.
 
-A carga máxima é
-\[
-  Q_{\max}=C\Delta V_{\max}
-  = \Sexpr{nota_cient(C)}\cdot \Sexpr{deltaV}
-  = \Sexpr{nota_cient(Qmax)}\,\mathrm{C},
-\]
-ou seja, $\Sexpr{Qmax_uC}\,\mu\mathrm{C}$.
-
-A energia armazenada no capacitor é
-\[
-  U=\frac{Q_{\max}\Delta V_{\max}}{2}
-  =\frac{\Sexpr{nota_cient(Qmax)}\cdot \Sexpr{deltaV}}{2}
-  =\Sexpr{E}\,\mathrm{J}.
-\]
-
-Portanto:
 \begin{answerlist}
   \item $\Sexpr{epsilon_pico}$.
-  \item A capacitância é $\Sexpr{C_nF}\,\mathrm{nF}$.
-  \item A carga máxima é $\Sexpr{Qmax_uC}\,\mu\mathrm{C}$.
-  \item A energia é $\Sexpr{E}\,\mathrm{J}$.
+  \item A capacitância é $\Sexpr{C_nF}$ nF.
+  \item A carga máxima é $\Sexpr{Qmax_uC}$ $\mu C$.
+  \item A energia é $\Sexpr{E}$ J.
 \end{answerlist}
 \end{solution}
 

--- a/BancoDeQuestoes/eletromagnetismo/eletrostática/Q03Capacitores.Rnw
+++ b/BancoDeQuestoes/eletromagnetismo/eletrostática/Q03Capacitores.Rnw
@@ -19,8 +19,20 @@ No esquema a seguir estão representados cinco capacitores, de capacidades $C_1$
 \end{question}
 
 \begin{solution}
-%% Supply a solution here!
-A capacitância é $\Sexpr{resp}$pF.
+
+Em uma associação de capacitores em paralelo, todos os capacitores ficam submetidos à mesma diferença de potencial. Nessa situação, a capacitância equivalente é a soma das capacitâncias individuais:
+\[
+  C_{eq}=C_1+C_2+C_3+C_4+C_5.
+\]
+
+Substituindo os valores do enunciado,
+\[
+  C_{eq}=\Sexpr{C[1]}+\Sexpr{C[2]}+\Sexpr{C[3]}+\Sexpr{C[4]}+\Sexpr{C[5]}
+  =\Sexpr{resp}\,\mathrm{pF}.
+\]
+
+Portanto, a capacitância equivalente da associação é $\Sexpr{resp}\,\mathrm{pF}$.
+
 \end{solution}
 
 %% META-INFORMATION

--- a/BancoDeQuestoes/eletromagnetismo/eletrostática/Q03Capacitores.Rnw
+++ b/BancoDeQuestoes/eletromagnetismo/eletrostática/Q03Capacitores.Rnw
@@ -20,18 +20,9 @@ No esquema a seguir estão representados cinco capacitores, de capacidades $C_1$
 
 \begin{solution}
 
-Em uma associação de capacitores em paralelo, todos os capacitores ficam submetidos à mesma diferença de potencial. Nessa situação, a capacitância equivalente é a soma das capacitâncias individuais:
-\[
-  C_{eq}=C_1+C_2+C_3+C_4+C_5.
-\]
+Em uma associação de capacitores em paralelo, a capacitância equivalente é a soma das capacitâncias individuais. Assim, $C_{eq}=\Sexpr{C[1]}+\Sexpr{C[2]}+\Sexpr{C[3]}+\Sexpr{C[4]}+\Sexpr{C[5]}=\Sexpr{resp}$ pF.
 
-Substituindo os valores do enunciado,
-\[
-  C_{eq}=\Sexpr{C[1]}+\Sexpr{C[2]}+\Sexpr{C[3]}+\Sexpr{C[4]}+\Sexpr{C[5]}
-  =\Sexpr{resp}\,\mathrm{pF}.
-\]
-
-Portanto, a capacitância equivalente da associação é $\Sexpr{resp}\,\mathrm{pF}$.
+Portanto, a capacitância equivalente da associação é \Sexpr{resp} pF.
 
 \end{solution}
 

--- a/BancoDeQuestoes/hidrostatica/Q04Densidade.Rnw
+++ b/BancoDeQuestoes/hidrostatica/Q04Densidade.Rnw
@@ -14,14 +14,41 @@ massa2
 \begin{question}
 %% Enunciado
 Um cubo de material homog\^eneo, tem \Sexpr{aresta1} cm de aresta e massa igual a \Sexpr{massa1} g. Outro cubo de mesmo
-material e igualment e homog\^eneo, tem \Sexpr{aresta2} cm de aresta. Qual \'e o valor da sua massa em gramas? (OBS: arredonde para uma decimal.)
+material e igualmente homog\^eneo, tem \Sexpr{aresta2} cm de aresta. Qual \'e o valor da sua massa em gramas? (OBS: arredonde para uma decimal.)
 
 
 \end{question}
 
 \begin{solution}
-%% Supply a solution here!
-A massa \'e \Sexpr{massa2}.
+
+Como os dois cubos são feitos do mesmo material homogêneo, eles têm a mesma densidade.
+
+Primeiro calculamos a densidade usando o cubo conhecido. O volume de um cubo é
+\[
+  V=a^3.
+\]
+Assim, para o primeiro cubo,
+\[
+  V_1=(\Sexpr{aresta1})^3=\Sexpr{aresta1^3}\,\mathrm{cm^3}.
+\]
+A densidade do material é
+\[
+  \rho=\frac{m_1}{V_1}=\frac{\Sexpr{massa1}}{\Sexpr{aresta1^3}}
+  \approx \Sexpr{round(massa1/aresta1^3,2)}\,\mathrm{g/cm^3}.
+\]
+
+O segundo cubo tem volume
+\[
+  V_2=(\Sexpr{aresta2})^3=\Sexpr{round(aresta2^3,3)}\,\mathrm{cm^3}.
+\]
+Logo, sua massa é
+\[
+  m_2=\rho V_2
+  \approx \Sexpr{round(massa1/aresta1^3,2)}\cdot \Sexpr{round(aresta2^3,3)}
+  = \Sexpr{massa2}\,\mathrm{g}.
+\]
+
+Portanto, a massa do segundo cubo é $\Sexpr{massa2}\,\mathrm{g}$.
 
 \end{solution}
 

--- a/BancoDeQuestoes/hidrostatica/Q04Densidade.Rnw
+++ b/BancoDeQuestoes/hidrostatica/Q04Densidade.Rnw
@@ -21,34 +21,13 @@ material e igualmente homog\^eneo, tem \Sexpr{aresta2} cm de aresta. Qual \'e o 
 
 \begin{solution}
 
-Como os dois cubos são feitos do mesmo material homogêneo, eles têm a mesma densidade.
+Como os dois cubos são feitos do mesmo material homogêneo, eles têm a mesma densidade. O volume de um cubo é dado pela aresta elevada ao cubo.
 
-Primeiro calculamos a densidade usando o cubo conhecido. O volume de um cubo é
-\[
-  V=a^3.
-\]
-Assim, para o primeiro cubo,
-\[
-  V_1=(\Sexpr{aresta1})^3=\Sexpr{aresta1^3}\,\mathrm{cm^3}.
-\]
-A densidade do material é
-\[
-  \rho=\frac{m_1}{V_1}=\frac{\Sexpr{massa1}}{\Sexpr{aresta1^3}}
-  \approx \Sexpr{round(massa1/aresta1^3,2)}\,\mathrm{g/cm^3}.
-\]
+Para o primeiro cubo, o volume é \Sexpr{aresta1} ao cubo, isto é, \Sexpr{aresta1^3} cm³. A densidade do material é então aproximadamente \Sexpr{round(massa1/aresta1^3,2)} g/cm³.
 
-O segundo cubo tem volume
-\[
-  V_2=(\Sexpr{aresta2})^3=\Sexpr{round(aresta2^3,3)}\,\mathrm{cm^3}.
-\]
-Logo, sua massa é
-\[
-  m_2=\rho V_2
-  \approx \Sexpr{round(massa1/aresta1^3,2)}\cdot \Sexpr{round(aresta2^3,3)}
-  = \Sexpr{massa2}\,\mathrm{g}.
-\]
+O segundo cubo tem volume aproximadamente \Sexpr{round(aresta2^3,3)} cm³. Multiplicando esse volume pela mesma densidade, obtemos a massa \Sexpr{massa2} g.
 
-Portanto, a massa do segundo cubo é $\Sexpr{massa2}\,\mathrm{g}$.
+Portanto, a massa do segundo cubo é \Sexpr{massa2} g.
 
 \end{solution}
 

--- a/BancoDeQuestoes/hidrostatica/Q05Densidade.Rnw
+++ b/BancoDeQuestoes/hidrostatica/Q05Densidade.Rnw
@@ -3,10 +3,11 @@
 ## Parâmetros
 densidade <- signif(runif(n = 1, min = 0.2, max = 3),2)
 massa <- sample(200000:2000000,1)
-volume <- round(massa*densidade,1)
+volume <- round(massa/densidade,1)
 
 ## Solução
-solutions <- c(0.5, 0.75, 1, 2.5, 1.5) > densidade
+dens_esferas <- c(0.5, 0.75, 1, 2.5, 1.5)
+solutions <- dens_esferas > densidade
 solutions
 ## Figura
 include_supplement('Q05Densidade.png')
@@ -30,7 +31,28 @@ O líquido contido no recipiente nessa figura tem um volume V' = \Sexpr{round(vo
 \end{question}
 
 \begin{solution}
-%% Supply a solution here!
+
+Para saber se a esfera afunda, comparamos sua densidade com a densidade do líquido. A esfera afunda quando
+\[
+  d_{\text{esfera}} > d_{\text{líquido}}.
+\]
+
+A densidade do líquido pode ser obtida pelos dados do enunciado. Como $\Sexpr{round(massa/1000,2)}\,\mathrm{kg}=\Sexpr{massa}\,\mathrm{g}$ e $\Sexpr{round(volume/100^3,2)}\,\mathrm{m^3}=\Sexpr{round(volume,1)}\,\mathrm{cm^3}$, temos
+\[
+  d_{\text{líquido}}=\frac{m'}{V'}=\frac{\Sexpr{massa}}{\Sexpr{round(volume,1)}}
+  \approx \Sexpr{densidade}\,\mathrm{g/cm^3}.
+\]
+
+Agora analisamos cada alternativa:
+\begin{answerlist}
+  \item $d=0{,}50\,\mathrm{g/cm^3}$. Afunda se $0{,}50>\Sexpr{densidade}$.
+  \item $d=\frac{150}{200}=0{,}75\,\mathrm{g/cm^3}$. Afunda se $0{,}75>\Sexpr{densidade}$.
+  \item $d=1{,}0\,\mathrm{g/cm^3}$. Afunda se $1{,}0>\Sexpr{densidade}$.
+  \item $d=2{,}5\,\mathrm{g/cm^3}$. Afunda se $2{,}5>\Sexpr{densidade}$.
+  \item $d=\frac{1500}{1000}=1{,}5\,\mathrm{g/cm^3}$. Afunda se $1{,}5>\Sexpr{densidade}$.
+\end{answerlist}
+
+Portanto, as alternativas corretas são:
 <<echo=FALSE, results=tex>>=
 answerlist(solutions)
 @

--- a/BancoDeQuestoes/hidrostatica/Q05Densidade.Rnw
+++ b/BancoDeQuestoes/hidrostatica/Q05Densidade.Rnw
@@ -34,12 +34,12 @@ O líquido contido no recipiente nessa figura tem um volume V' = \Sexpr{round(vo
 
 Para saber se a esfera afunda, comparamos sua densidade com a densidade do líquido. A esfera afunda quando
 \[
-  d_{\text{esfera}} > d_{\text{líquido}}.
+  d_{esfera} > d_{liquido}.
 \]
 
 A densidade do líquido pode ser obtida pelos dados do enunciado. Como $\Sexpr{round(massa/1000,2)}\,\mathrm{kg}=\Sexpr{massa}\,\mathrm{g}$ e $\Sexpr{round(volume/100^3,2)}\,\mathrm{m^3}=\Sexpr{round(volume,1)}\,\mathrm{cm^3}$, temos
 \[
-  d_{\text{líquido}}=\frac{m'}{V'}=\frac{\Sexpr{massa}}{\Sexpr{round(volume,1)}}
+  d_{liquido}=\frac{m'}{V'}=\frac{\Sexpr{massa}}{\Sexpr{round(volume,1)}}
   \approx \Sexpr{densidade}\,\mathrm{g/cm^3}.
 \]
 

--- a/BancoDeQuestoes/hidrostatica/Q05Densidade.Rnw
+++ b/BancoDeQuestoes/hidrostatica/Q05Densidade.Rnw
@@ -6,8 +6,7 @@ massa <- sample(200000:2000000,1)
 volume <- round(massa/densidade,1)
 
 ## Solução
-dens_esferas <- c(0.5, 0.75, 1, 2.5, 1.5)
-solutions <- dens_esferas > densidade
+solutions <- c(0.5, 0.75, 1, 2.5, 1.5) > densidade
 solutions
 ## Figura
 include_supplement('Q05Densidade.png')
@@ -31,28 +30,11 @@ O líquido contido no recipiente nessa figura tem um volume V' = \Sexpr{round(vo
 \end{question}
 
 \begin{solution}
+A densidade do líquido é obtida por massa dividida pelo volume. Pelos valores do enunciado, ela é aproximadamente \Sexpr{densidade} g/cm³.
 
-Para saber se a esfera afunda, comparamos sua densidade com a densidade do líquido. A esfera afunda quando
-\[
-  d_{esfera} > d_{liquido}.
-\]
+Uma esfera afunda quando sua densidade é maior que a densidade do líquido. Assim, basta comparar a densidade de cada alternativa com \Sexpr{densidade} g/cm³.
 
-A densidade do líquido pode ser obtida pelos dados do enunciado. Como $\Sexpr{round(massa/1000,2)}\,\mathrm{kg}=\Sexpr{massa}\,\mathrm{g}$ e $\Sexpr{round(volume/100^3,2)}\,\mathrm{m^3}=\Sexpr{round(volume,1)}\,\mathrm{cm^3}$, temos
-\[
-  d_{liquido}=\frac{m'}{V'}=\frac{\Sexpr{massa}}{\Sexpr{round(volume,1)}}
-  \approx \Sexpr{densidade}\,\mathrm{g/cm^3}.
-\]
-
-Agora analisamos cada alternativa:
-\begin{answerlist}
-  \item $d=0{,}50\,\mathrm{g/cm^3}$. Afunda se $0{,}50>\Sexpr{densidade}$.
-  \item $d=\frac{150}{200}=0{,}75\,\mathrm{g/cm^3}$. Afunda se $0{,}75>\Sexpr{densidade}$.
-  \item $d=1{,}0\,\mathrm{g/cm^3}$. Afunda se $1{,}0>\Sexpr{densidade}$.
-  \item $d=2{,}5\,\mathrm{g/cm^3}$. Afunda se $2{,}5>\Sexpr{densidade}$.
-  \item $d=\frac{1500}{1000}=1{,}5\,\mathrm{g/cm^3}$. Afunda se $1{,}5>\Sexpr{densidade}$.
-\end{answerlist}
-
-Portanto, as alternativas corretas são:
+As alternativas que afundam são:
 <<echo=FALSE, results=tex>>=
 answerlist(solutions)
 @


### PR DESCRIPTION
## Resumo

Segundo lote de melhoria pedagógica dos solucionários antigos. Este PR substitui soluções curtas ou com placeholder por explicações passo a passo em questões de densidade/hidrostatica e eletrostática/capacitores.

## Questões atualizadas

- `BancoDeQuestoes/hidrostatica/Q04Densidade.Rnw`
  - Explica o uso da densidade comum aos dois cubos.
  - Mostra o cálculo dos volumes por `V = a^3` e da massa por `m = rho V`.

- `BancoDeQuestoes/hidrostatica/Q05Densidade.Rnw`
  - Explica o critério de afundamento por comparação de densidades.
  - Corrige a geração do volume do líquido para ficar consistente com `rho = m/V`.
  - Mostra a densidade associada a cada alternativa.

- `BancoDeQuestoes/eletromagnetismo/eletrostática/Q01Capacitores.Rnw`
  - Explica o uso de potencial nulo no ponto M para obter a carga da esfera B.
  - Explica a capacitância de esfera condutora isolada.
  - Explica conservação da carga e igualdade de potencial após ligar as esferas por fio condutor.

- `BancoDeQuestoes/eletromagnetismo/eletrostática/Q02Capacitores.Rnw`
  - Explica permissividade do dielétrico, capacitância de placas paralelas, tensão máxima pela rigidez dielétrica, carga máxima e energia armazenada.
  - Mantém as respostas nas unidades pedidas pelo enunciado.

- `BancoDeQuestoes/eletromagnetismo/eletrostática/Q03Capacitores.Rnw`
  - Explica que, em paralelo, a capacitância equivalente é a soma das capacitâncias.

## Observações

Este lote também remove placeholders do tipo `Supply a solution here` nessas questões e segue a estratégia de PRs pequenos por assunto.

## Testes

Não executei os testes localmente nesta interface. O PR deve ser validado pelo workflow de R tests.