### PR TITLE
Publicar vitrine no GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,42 @@
+name: Public site
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'site/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload public site artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Resumo

Este PR adiciona um workflow para publicar a vitrine pública do BancoFisica no GitHub Pages a partir da pasta `site/`.

Resolve #37.

## O que foi incluído

- `.github/workflows/pages.yml`
- Deploy manual por `workflow_dispatch`.
- Deploy automático em push na `master` quando houver mudanças em `site/**` ou no próprio workflow.
- Publicação somente do conteúdo da pasta `site/`.

## Decisão de escopo

Este PR não mexe no conteúdo das questões nem gera novos dados. Ele apenas publica a vitrine já adicionada no PR #35.

## Segurança avaliativa

O workflow publica apenas os arquivos em `site/`. O banco completo de questões não é incluído como artefato do Pages.