### PR TITLE
Definir política de visibilidade da vitrine pública

### DIFF
--- a/docs/politica-visibilidade-site.md
+++ b/docs/politica-visibilidade-site.md
@@ -1,0 +1,86 @@
+# Política de visibilidade da vitrine pública
+
+Esta política define quais conteúdos do BancoFisica podem ser publicados no site público do projeto.
+
+## Objetivo
+
+O site público do BancoFisica é uma vitrine institucional e pedagógica. Ele serve para apresentar o projeto, explicar seu funcionamento, documentar o uso com R/exams e Moodle e mostrar alguns exemplos demonstrativos.
+
+O site não deve expor o banco completo de questões usado em avaliações reais.
+
+## Regra central
+
+Somente conteúdos marcados explicitamente como demonstrativos podem ser publicados no site público.
+
+Questões reais, questões ainda não revisadas, gabaritos completos, arquivos de exportação avaliativa e variações usadas em provas ou questionários reais não devem ser incluídos automaticamente na vitrine pública.
+
+## Níveis de visibilidade
+
+Ao criar metadados para exportação pública, use um dos níveis abaixo.
+
+### `demo`
+
+Pode aparecer no site público.
+
+Use apenas para itens criados com finalidade demonstrativa, exemplos sacrificáveis ou versões adaptadas que não serão usadas como questão avaliativa real.
+
+### `private`
+
+Não pode aparecer no site público.
+
+Use para questões do banco avaliativo, questões que podem ser usadas em Moodle, provas, listas avaliativas, simulados ou qualquer atividade em que a exposição pública prejudique a segurança avaliativa.
+
+### `internal`
+
+Não deve aparecer no site público por padrão.
+
+Use para testes, rascunhos, documentação interna, scripts auxiliares ou itens em revisão. Um item `internal` só pode ser publicado se for revisado e convertido explicitamente para `demo`.
+
+## Política para scripts de exportação
+
+Qualquer script que gere dados para o site deve seguir as regras abaixo:
+
+1. exportar somente itens com `visibility = "demo"`;
+2. rejeitar ou ignorar itens sem campo de visibilidade;
+3. nunca usar `private` como valor padrão para publicação;
+4. registrar no JSON público que os dados são demonstrativos;
+5. evitar incluir identificadores, gabaritos ou textos de questões avaliativas reais.
+
+## Política para solucionários
+
+Soluções podem aparecer no site somente quando a questão também for demonstrativa.
+
+Soluções de questões privadas não devem ser expostas na vitrine pública, mesmo quando o enunciado não for publicado.
+
+## Política para Moodle
+
+A vitrine pode mostrar uma simulação visual de como uma questão demonstrativa apareceria em ambiente virtual.
+
+O site público não deve publicar automaticamente XMLs avaliativos completos, bancos de questões completos ou pacotes de importação usados em avaliações reais.
+
+## Exemplo de metadado público
+
+```json
+{
+  "id": "DEMO-MEC-001",
+  "title": "Velocidade média em um trajeto retilíneo",
+  "area": "Mecânica",
+  "subject": "Cinemática",
+  "level": "Ensino Médio",
+  "visibility": "demo",
+  "tags": ["velocidade média", "unidades", "moodle"]
+}
+```
+
+## Critério de revisão
+
+Antes de publicar ou automatizar dados para o site, revise se:
+
+- o item foi criado para demonstração;
+- o item não será usado em avaliação real;
+- a solução pode ser divulgada sem comprometer atividades futuras;
+- o conteúdo não revela estrutura, gabarito ou parametrização de questões privadas.
+
+## Relação com o projeto do site
+
+Esta política atende à issue #38 e deve orientar as próximas etapas do projeto do site, especialmente o gerador automático de `site/data/questoes-demo.json`.

--- a/site/css/style.css
+++ b/site/css/style.css
@@ -90,7 +90,8 @@ a {
 
 .hero h1,
 .section-heading h1,
-.section-heading h2 {
+.section-heading h2,
+.doc-page h1 {
   margin: 0;
   line-height: 1.08;
   letter-spacing: -0.05em;
@@ -106,6 +107,10 @@ a {
   margin: 1.5rem 0 0;
   color: var(--muted);
   font-size: 1.2rem;
+}
+
+.lead.compact {
+  max-width: 820px;
 }
 
 .eyebrow {
@@ -155,7 +160,8 @@ a {
 .card,
 .notice,
 .question-card,
-.filters {
+.filters,
+.doc-page {
   background: var(--surface);
   border: 1px solid var(--line);
   border-radius: 24px;
@@ -183,7 +189,8 @@ a {
 }
 
 .section-heading h1,
-.section-heading h2 {
+.section-heading h2,
+.doc-page h1 {
   font-size: clamp(2rem, 4vw, 3.4rem);
 }
 
@@ -334,6 +341,36 @@ summary {
 
 .question-body ol {
   padding-left: 1.4rem;
+}
+
+.doc-page {
+  padding: clamp(1.5rem, 4vw, 3rem);
+}
+
+.doc-page section {
+  margin-top: 2rem;
+}
+
+.doc-page h2 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.45rem, 3vw, 2rem);
+}
+
+.doc-page p,
+.doc-page li {
+  color: var(--muted);
+  font-size: 1.03rem;
+}
+
+.doc-page ul {
+  padding-left: 1.25rem;
+}
+
+code {
+  padding: 0.1rem 0.3rem;
+  border-radius: 0.4rem;
+  background: #f1f5f9;
+  color: #334155;
 }
 
 .footer {

--- a/site/index.html
+++ b/site/index.html
@@ -16,6 +16,7 @@
         <a class="brand" href="index.html">BancoFisica</a>
         <div class="nav-links">
           <a href="questoes.html">Questões demonstrativas</a>
+          <a href="visibilidade.html">Visibilidade</a>
           <a href="https://github.com/IFSP-HTO/BancoFisica">GitHub</a>
         </div>
       </nav>
@@ -34,6 +35,7 @@
             </p>
             <div class="actions">
               <a class="button primary" href="questoes.html">Ver demonstrações</a>
+              <a class="button secondary" href="visibilidade.html">Ver política de visibilidade</a>
               <a class="button secondary" href="https://github.com/IFSP-HTO/BancoFisica">Abrir repositório</a>
             </div>
           </div>
@@ -90,7 +92,8 @@
         <div class="notice">
           <strong>Regra do site:</strong>
           publicar apenas itens marcados como demonstrativos ou criados especificamente
-          para divulgação.
+          para divulgação. Consulte a
+          <a href="visibilidade.html">política de visibilidade</a>.
         </div>
       </section>
     </main>

--- a/site/questoes.html
+++ b/site/questoes.html
@@ -24,6 +24,7 @@
         <a class="brand" href="index.html">BancoFisica</a>
         <div class="nav-links">
           <a href="questoes.html" aria-current="page">Questões demonstrativas</a>
+          <a href="visibilidade.html">Visibilidade</a>
           <a href="https://github.com/IFSP-HTO/BancoFisica">GitHub</a>
         </div>
       </nav>
@@ -36,6 +37,8 @@
         <p>
           Esta página mostra apenas itens de demonstração. Ela existe para divulgar o
           formato do BancoFisica sem expor o banco completo usado em avaliações.
+          Consulte a <a href="visibilidade.html">política de visibilidade</a> para
+          entender quais conteúdos podem ser publicados na vitrine.
         </p>
       </div>
 

--- a/site/visibilidade.html
+++ b/site/visibilidade.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Política de visibilidade da vitrine pública do BancoFisica."
+    />
+    <title>Política de visibilidade | BancoFisica</title>
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav container" aria-label="Navegação principal">
+        <a class="brand" href="index.html">BancoFisica</a>
+        <div class="nav-links">
+          <a href="questoes.html">Questões demonstrativas</a>
+          <a href="visibilidade.html" aria-current="page">Visibilidade</a>
+          <a href="https://github.com/IFSP-HTO/BancoFisica">GitHub</a>
+        </div>
+      </nav>
+    </header>
+
+    <main class="container section">
+      <article class="doc-page">
+        <p class="eyebrow">Segurança avaliativa</p>
+        <h1>Política de visibilidade da vitrine pública</h1>
+        <p class="lead compact">
+          O site público do BancoFisica é uma vitrine institucional e pedagógica. Ele
+          não deve expor o banco completo de questões usado em avaliações reais.
+        </p>
+
+        <section>
+          <h2>Regra central</h2>
+          <p>
+            Somente conteúdos marcados explicitamente como demonstrativos podem ser
+            publicados no site público.
+          </p>
+          <p>
+            Questões reais, questões ainda não revisadas, gabaritos completos,
+            arquivos de exportação avaliativa e variações usadas em provas ou
+            questionários reais não devem ser incluídos automaticamente na vitrine.
+          </p>
+        </section>
+
+        <section>
+          <h2>Níveis de visibilidade</h2>
+          <div class="cards three-columns">
+            <article class="card">
+              <h3><code>demo</code></h3>
+              <p>
+                Pode aparecer no site público. Use apenas para exemplos criados com
+                finalidade demonstrativa ou versões que não serão usadas em avaliação.
+              </p>
+            </article>
+            <article class="card">
+              <h3><code>private</code></h3>
+              <p>
+                Não pode aparecer no site público. Use para questões do banco
+                avaliativo, provas, listas avaliativas, simulados e uso real em Moodle.
+              </p>
+            </article>
+            <article class="card">
+              <h3><code>internal</code></h3>
+              <p>
+                Não deve aparecer no site por padrão. Use para rascunhos, testes,
+                documentação interna ou itens ainda em revisão.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section>
+          <h2>Scripts de exportação</h2>
+          <p>Qualquer script que gere dados para o site deve:</p>
+          <ul>
+            <li>exportar somente itens com <code>visibility = "demo"</code>;</li>
+            <li>rejeitar ou ignorar itens sem campo de visibilidade;</li>
+            <li>registrar que o JSON público contém apenas dados demonstrativos;</li>
+            <li>evitar incluir identificadores, gabaritos ou textos de questões avaliativas reais.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>Soluções e Moodle</h2>
+          <p>
+            Soluções podem aparecer no site somente quando a questão também for
+            demonstrativa. A vitrine pode mostrar uma simulação visual de Moodle, mas
+            não deve publicar automaticamente XMLs avaliativos completos nem pacotes de
+            importação usados em avaliações reais.
+          </p>
+        </section>
+
+        <section>
+          <h2>Documento completo</h2>
+          <p>
+            A versão canônica desta política fica no repositório, em
+            <code>docs/politica-visibilidade-site.md</code>.
+          </p>
+        </section>
+      </article>
+    </main>
+
+    <footer class="footer">
+      <div class="container">
+        <p>
+          BancoFisica — vitrine pública com questões demonstrativas.
+        </p>
+      </div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Resumo

Este PR define a política de visibilidade para o site público do BancoFisica.

Resolve #38.

## O que foi incluído

- `docs/politica-visibilidade-site.md`: documento canônico da política.
- `site/visibilidade.html`: versão pública da política no site.
- Links para a política na página inicial e no catálogo de questões demonstrativas.
- Ajustes de CSS para a nova página documental.

## Decisão de segurança avaliativa

A regra central passa a ser explícita: somente itens com `visibility = "demo"` podem ser publicados no site.

Itens privados, internos, usados em avaliações reais ou sem campo explícito de visibilidade não devem ser exportados para a vitrine.

## Fora do escopo

- Gerador automático de JSON.
- Preview Moodle.
- Mudança no banco real de questões.