### PR TITLE
Valida Moodle XML gerado no CI

### DIFF
--- a/tests/tests.R
+++ b/tests/tests.R
@@ -38,7 +38,7 @@ check_encoding <- function() {
 ## ao longo de uma sessão; rodando 200+ compilações no mesmo processo isso
 ## corrompe o tempdir/cwd e gera falhas intermitentes ("argumento 'path'
 ## inválido"). Isolar cada compilação num subprocesso elimina esse acúmulo.
-## O set.seed deixa a execução reprodutível. Retorna TRUE/FALSE.
+## O set.seed deixa a execução reprodutível. Retorna uma lista diagnóstica.
 compilar_isolado <- function(arquivo, diretorio, formato, ano, seed) {
   tryCatch({
     callr::r(
@@ -48,25 +48,89 @@ compilar_isolado <- function(arquivo, diretorio, formato, ano, seed) {
         suppressMessages({
           library(magrittr); library(stringr); library(exams); library(purrr)
         })
+
+        count_matches <- function(text, pattern) {
+          hits <- gregexpr(pattern, text, perl = TRUE)[[1]]
+          if (identical(hits, -1L)) return(0L)
+          length(hits)
+        }
+
+        validate_moodle_xml <- function(xml_file) {
+          if (!file.exists(xml_file)) {
+            stop("Moodle XML file not found: ", xml_file)
+          }
+
+          xml_text <- paste(readLines(xml_file, warn = FALSE, encoding = "UTF-8"), collapse = "\n")
+          xml_bytes <- file.info(xml_file)$size
+
+          if (!grepl("<quiz[[:space:]>]", xml_text, perl = TRUE)) {
+            stop("Moodle XML missing <quiz> root in ", basename(xml_file))
+          }
+          if (!grepl("</quiz>", xml_text, fixed = TRUE)) {
+            stop("Moodle XML missing </quiz> closing tag in ", basename(xml_file))
+          }
+          if (grepl("<parsererror", xml_text, fixed = TRUE)) {
+            stop("Moodle XML contains parsererror marker in ", basename(xml_file))
+          }
+
+          question_tags <- regmatches(
+            xml_text,
+            gregexpr("<question[[:space:]]+type=\"[^\"]+\"", xml_text, perl = TRUE)
+          )[[1]]
+          if (length(question_tags) == 1L && identical(question_tags, -1L)) {
+            question_tags <- character()
+          }
+          n_questions <- sum(!grepl("type=\"category\"", question_tags, fixed = TRUE))
+          if (n_questions < 1L) {
+            stop("Moodle XML has no exported question item in ", basename(xml_file))
+          }
+
+          list(
+            xml_file = basename(xml_file),
+            xml_bytes = xml_bytes,
+            xml_questions = n_questions,
+            quiz_tags = count_matches(xml_text, "<quiz[[:space:]>]"),
+            raw_question_tags = length(question_tags)
+          )
+        }
+
         set.seed(seed)
         if (formato == "xml") {
+          xml_before <- list.files(tempdir(), pattern = "\\.xml$", full.names = TRUE)
           exams2moodle(arquivo, n = 1, rule = "none",
                        schoice = list(shuffle = TRUE),
                        name = paste0("exemplos-", ano),
                        encoding = "UTF-8", dir = tempdir(), edir = diretorio)
-        } else {
-          exams2pdf(arquivo, n = 1,
-                    name = paste0("exemplos-", ano),
-                    encoding = "UTF-8", dir = tempdir(), edir = diretorio,
-                    template = "plain8")
+          xml_after <- list.files(tempdir(), pattern = "\\.xml$", full.names = TRUE)
+          xml_new <- setdiff(xml_after, xml_before)
+          if (length(xml_new) == 0L) {
+            xml_new <- xml_after
+          }
+          if (length(xml_new) == 0L) {
+            stop("exams2moodle did not generate an XML file")
+          }
+
+          xml_new <- xml_new[order(file.info(xml_new)$mtime, decreasing = TRUE)]
+          xml_info <- validate_moodle_xml(xml_new[1])
+          return(c(list(ok = TRUE, message = ""), xml_info))
         }
-        invisible(TRUE)
+
+        exams2pdf(arquivo, n = 1,
+                  name = paste0("exemplos-", ano),
+                  encoding = "UTF-8", dir = tempdir(), edir = diretorio,
+                  template = "plain8")
+        list(ok = TRUE, message = "", xml_file = NA_character_,
+             xml_bytes = NA_real_, xml_questions = NA_integer_,
+             quiz_tags = NA_integer_, raw_question_tags = NA_integer_)
       },
       args = list(arquivo = arquivo, diretorio = diretorio,
                   formato = formato, ano = ano, seed = seed)
     )
-    TRUE
-  }, error = function(e) FALSE)
+  }, error = function(e) {
+    list(ok = FALSE, message = conditionMessage(e), xml_file = NA_character_,
+         xml_bytes = NA_real_, xml_questions = NA_integer_,
+         quiz_tags = NA_integer_, raw_question_tags = NA_integer_)
+  })
 }
 
 ## Valida a geração do gráfico sem exigir artefatos versionados no PR.
@@ -92,6 +156,9 @@ check_bank_structure <- function() {
 }
 
 ## Verifica a compilação para XML
+##
+## Além de checar se o exams2moodle roda, valida o artefato gerado:
+## precisa existir, conter raiz <quiz>...</quiz> e ao menos uma questão Moodle.
 generate_xml <- function() {
 
   ## Pega todos os arquivos de questões
@@ -102,20 +169,42 @@ generate_xml <- function() {
   ano <- 2018
 
   ## Para cada arquivo, compila para XML numa sessão isolada
-  ok <- logical(nrow(arquivos))
+  resultados <- vector("list", nrow(arquivos))
   for (i in seq_len(nrow(arquivos))) {
     arquivo   <- normalizePath(arquivos$file[i])
     diretorio <- dirname(arquivo)
-    ok[i] <- compilar_isolado(arquivo, diretorio, "xml", ano, seed = i)
+    resultados[[i]] <- compilar_isolado(arquivo, diretorio, "xml", ano, seed = i)
   }
 
+  xml_report <- do.call(rbind, lapply(seq_along(resultados), function(i) {
+    res <- resultados[[i]]
+    data.frame(
+      file = arquivos$file[i],
+      ok = isTRUE(res$ok),
+      message = as.character(res$message),
+      xml_file = as.character(res$xml_file),
+      xml_bytes = as.numeric(res$xml_bytes),
+      xml_questions = as.integer(res$xml_questions),
+      quiz_tags = as.integer(res$quiz_tags),
+      raw_question_tags = as.integer(res$raw_question_tags),
+      stringsAsFactors = FALSE
+    )
+  }))
+
+  if (!dir.exists("build/moodle-xml")) {
+    dir.create("build/moodle-xml", recursive = TRUE)
+  }
+  write.csv(xml_report, "build/moodle-xml/xml-validation.csv",
+            row.names = FALSE, fileEncoding = "UTF-8")
+
   ## Encontrando as linhas com erros
-  ind_xml <- which(!ok)
+  ind_xml <- which(!xml_report$ok)
 
   ## Erro reportado
-  erro <- paste("NÃO COMPILA PARA XML:", arquivos$file[ind_xml], '\n')
+  erro <- paste("NÃO COMPILA OU NÃO VALIDA PARA XML:",
+                arquivos$file[ind_xml], xml_report$message[ind_xml], '\n')
 
-  ## Testando a compilação
+  ## Testando a compilação e validação
   if (length(ind_xml) > 0 ) stop(erro)
 }
 
@@ -134,7 +223,7 @@ generate_pdf <- function() {
   for (i in seq_len(nrow(arquivos))) {
     arquivo   <- normalizePath(arquivos$file[i])
     diretorio <- dirname(arquivo)
-    ok[i] <- compilar_isolado(arquivo, diretorio, "pdf", ano, seed = i)
+    ok[i] <- isTRUE(compilar_isolado(arquivo, diretorio, "pdf", ano, seed = i)$ok)
   }
 
   ## Encontrando as linhas com erros


### PR DESCRIPTION
## Resumo

Relacionado a #31.

Este PR fortalece a validação da exportação Moodle/XML no CI.

## O que muda

- A função de compilação isolada passa a retornar uma lista diagnóstica, não apenas `TRUE/FALSE`.
- Após cada chamada a `exams2moodle`, o teste agora localiza o `.xml` gerado no `tempdir()`.
- O XML gerado é validado quanto a:
  - existência do arquivo;
  - presença da raiz `<quiz>`;
  - presença do fechamento `</quiz>`;
  - ausência de marcador `<parsererror>`;
  - presença de pelo menos uma questão Moodle exportada, ignorando entradas `type="category"`.
- A etapa `generate_xml()` grava um CSV diagnóstico em `build/moodle-xml/xml-validation.csv`.
- Em caso de falha, a mensagem passa a distinguir erro de compilação e erro de validação do XML.

## Observação

A tentativa de adicionar upload explícito do CSV como artefato do workflow foi bloqueada pelo conector nesta sessão. O arquivo ainda é gerado localmente durante o CI e pode ser exposto como artefato em um PR posterior.

## Testes

A validação completa será executada pelo GitHub Actions neste PR.