### PR TITLE
Criar gerador automático do catálogo demonstrativo

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - 'site/**'
+      - 'tools/generate_demo_site_data.py'
       - '.github/workflows/pages.yml'
   workflow_dispatch:
 
@@ -28,6 +29,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Generate public demo question catalog
+        run: python3 tools/generate_demo_site_data.py
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/r-tests.yml
+++ b/.github/workflows/r-tests.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Validate public demo site data
+        run: |
+          python3 tools/generate_demo_site_data.py
+
       - name: Install system tools and LaTeX
         run: |
           sudo apt-get update -qq

--- a/site/data/questoes-demo-source.json
+++ b/site/data/questoes-demo-source.json
@@ -1,0 +1,42 @@
+{
+  "metadata": {
+    "project": "BancoFisica",
+    "description": "Dados públicos usados apenas na vitrine demonstrativa do site.",
+    "visibilityPolicy": "Somente questões com visibility=demo devem ser publicadas no site."
+  },
+  "questions": [
+    {
+      "id": "DEMO-MEC-001",
+      "title": "Velocidade média em um trajeto retilíneo",
+      "area": "Mecânica",
+      "subject": "Cinemática",
+      "level": "Ensino Médio",
+      "visibility": "demo",
+      "tags": ["velocidade média", "unidades", "moodle"],
+      "statementHtml": "<p>Um estudante percorre uma distância de \\(120\\,\\text{m}\\) em \\(30\\,\\text{s}\\), mantendo movimento retilíneo. Qual é a velocidade média nesse trecho?</p><ol type=\"A\"><li>\\(2\\,\\text{m/s}\\)</li><li>\\(4\\,\\text{m/s}\\)</li><li>\\(30\\,\\text{m/s}\\)</li><li>\\(150\\,\\text{m/s}\\)</li></ol>",
+      "solutionHtml": "<p>A velocidade média é dada por \\(v_m = \\Delta s / \\Delta t\\). Portanto, \\(v_m = 120/30 = 4\\,\\text{m/s}\\). A alternativa correta é B.</p>"
+    },
+    {
+      "id": "DEMO-TER-001",
+      "title": "Conversão de temperatura",
+      "area": "Termologia",
+      "subject": "Temperatura",
+      "level": "Ensino Médio",
+      "visibility": "demo",
+      "tags": ["temperatura", "Celsius", "Kelvin"],
+      "statementHtml": "<p>Em uma atividade de laboratório, a temperatura de uma amostra é medida como \\(27\\,^{\\circ}\\text{C}\\). Qual é o valor aproximado dessa temperatura na escala Kelvin?</p><ol type=\"A\"><li>\\(27\\,\\text{K}\\)</li><li>\\(100\\,\\text{K}\\)</li><li>\\(246\\,\\text{K}\\)</li><li>\\(300\\,\\text{K}\\)</li></ol>",
+      "solutionHtml": "<p>Para converter Celsius em Kelvin, usamos \\(T_K = T_C + 273\\). Assim, \\(T_K = 27 + 273 = 300\\,\\text{K}\\). A alternativa correta é D.</p>"
+    },
+    {
+      "id": "DEMO-ELE-001",
+      "title": "Lei de Ohm em um resistor",
+      "area": "Eletromagnetismo",
+      "subject": "Circuitos elétricos",
+      "level": "Ensino Médio",
+      "visibility": "demo",
+      "tags": ["lei de Ohm", "resistência elétrica", "corrente elétrica"],
+      "statementHtml": "<p>Um resistor de resistência \\(6\\,\\Omega\\) é submetido a uma diferença de potencial de \\(12\\,\\text{V}\\). Qual é a corrente elétrica que atravessa o resistor?</p><ol type=\"A\"><li>\\(0{,}5\\,\\text{A}\\)</li><li>\\(2\\,\\text{A}\\)</li><li>\\(6\\,\\text{A}\\)</li><li>\\(72\\,\\text{A}\\)</li></ol>",
+      "solutionHtml": "<p>Pela lei de Ohm, \\(U = R i\\). Logo, \\(i = U/R = 12/6 = 2\\,\\text{A}\\). A alternativa correta é B.</p>"
+    }
+  ]
+}

--- a/tools/generate_demo_site_data.py
+++ b/tools/generate_demo_site_data.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Generate the public demo question catalog for the BancoFisica site.
+
+The generator is intentionally conservative: it only exports questions marked
+explicitly with visibility = "demo". This keeps the public site aligned with the
+visibility policy documented in docs/politica-visibilidade-site.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REQUIRED_STRING_FIELDS = (
+    "id",
+    "title",
+    "area",
+    "subject",
+    "level",
+    "visibility",
+    "statementHtml",
+    "solutionHtml",
+)
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def require_object(value: Any, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        fail(f"{context} must be a JSON object")
+    return value
+
+
+def require_string(value: Any, context: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        fail(f"{context} must be a non-empty string")
+    return value
+
+
+def validate_question(question: dict[str, Any], index: int) -> None:
+    prefix = f"questions[{index}]"
+
+    for field in REQUIRED_STRING_FIELDS:
+        require_string(question.get(field), f"{prefix}.{field}")
+
+    if question["visibility"] != "demo":
+        fail(
+            f"{prefix} has visibility={question['visibility']!r}; "
+            "only visibility='demo' may be exported to the public site"
+        )
+
+    tags = question.get("tags")
+    if not isinstance(tags, list) or not tags:
+        fail(f"{prefix}.tags must be a non-empty list")
+
+    for tag_index, tag in enumerate(tags):
+        require_string(tag, f"{prefix}.tags[{tag_index}]")
+
+
+
+def validate_catalog(catalog: dict[str, Any]) -> None:
+    metadata = require_object(catalog.get("metadata"), "metadata")
+    require_string(metadata.get("project"), "metadata.project")
+    require_string(metadata.get("description"), "metadata.description")
+    require_string(metadata.get("visibilityPolicy"), "metadata.visibilityPolicy")
+
+    questions = catalog.get("questions")
+    if not isinstance(questions, list) or not questions:
+        fail("questions must be a non-empty list")
+
+    seen_ids: set[str] = set()
+    for index, question_value in enumerate(questions):
+        question = require_object(question_value, f"questions[{index}]")
+        validate_question(question, index)
+        question_id = question["id"]
+        if question_id in seen_ids:
+            fail(f"duplicated question id: {question_id}")
+        seen_ids.add(question_id)
+
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return require_object(json.load(handle), str(path))
+    except FileNotFoundError:
+        fail(f"file not found: {path}")
+    except json.JSONDecodeError as error:
+        fail(f"invalid JSON in {path}: {error}")
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate site/data/questoes-demo.json from a validated demo source."
+    )
+    parser.add_argument(
+        "--source",
+        default="site/data/questoes-demo-source.json",
+        help="source JSON with explicitly public demo questions",
+    )
+    parser.add_argument(
+        "--output",
+        default="site/data/questoes-demo.json",
+        help="generated JSON consumed by the public site",
+    )
+    args = parser.parse_args()
+
+    source_path = Path(args.source)
+    output_path = Path(args.output)
+
+    catalog = load_json(source_path)
+    validate_catalog(catalog)
+    write_json(output_path, catalog)
+
+    print(
+        f"Generated {output_path} from {source_path} "
+        f"with {len(catalog['questions'])} demo questions."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Resumo

Este PR cria o primeiro gerador automático de `site/data/questoes-demo.json`.

Resolve #41.

## O que foi incluído

- `site/data/questoes-demo-source.json`: fonte editável das questões públicas demonstrativas.
- `tools/generate_demo_site_data.py`: gerador e validador do catálogo público.
- Atualização do workflow `Public site` para regenerar o catálogo antes do deploy no GitHub Pages.
- Atualização do workflow `R tests` para validar os dados demonstrativos nos PRs.

## Regra de segurança

O gerador só aceita questões com `visibility = "demo"`.

Ele falha se encontrar:

- questão sem campo de visibilidade;
- questão com `visibility` diferente de `demo`;
- campos obrigatórios vazios;
- tags vazias;
- IDs duplicados.

## Decisão de escopo

Este PR ainda não extrai dados dos arquivos reais do BancoFisica. A fonte pública continua separada e controlada para evitar vazamento do banco avaliativo.