### PR TITLE
Criar preview estilo Moodle para questões demonstrativas

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -343,6 +343,108 @@ summary {
   padding-left: 1.4rem;
 }
 
+.moodle-preview {
+  margin-top: 0.85rem;
+}
+
+.moodle-card {
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: #f8fafc;
+}
+
+.moodle-toolbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--line);
+  background: #eef4ff;
+}
+
+.moodle-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+  color: #1e3a8a;
+  background: #dbeafe;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.moodle-context,
+.moodle-note,
+.moodle-label {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.moodle-question {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  gap: 0.9rem;
+  padding: 1rem;
+  background: white;
+}
+
+.moodle-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  color: white;
+  background: var(--primary);
+  font-weight: 900;
+}
+
+.moodle-content {
+  min-width: 0;
+}
+
+.moodle-label {
+  margin: 0 0 0.35rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
+.moodle-statement ol {
+  display: grid;
+  gap: 0.5rem;
+  padding-left: 1.35rem;
+}
+
+.moodle-statement li {
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.moodle-feedback {
+  margin: 1rem;
+  padding: 0.85rem 1rem;
+  border-left: 4px solid var(--accent);
+  border-radius: 12px;
+  background: #ecfdf5;
+}
+
+.moodle-feedback p:last-child,
+.moodle-statement p:last-child {
+  margin-bottom: 0;
+}
+
+.moodle-note {
+  margin: 0;
+  padding: 0 1rem 1rem;
+}
+
 .doc-page {
   padding: clamp(1.5rem, 4vw, 3rem);
 }
@@ -384,7 +486,8 @@ code {
   .hero-grid,
   .three-columns,
   .split,
-  .filters {
+  .filters,
+  .moodle-question {
     grid-template-columns: 1fr;
   }
 

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -121,6 +121,7 @@ function renderQuestion(question) {
   const tags = fragment.querySelector('.tags');
   const body = fragment.querySelector('.question-body');
   const solution = fragment.querySelector('.solution-body');
+  const moodlePreview = fragment.querySelector('.moodle-preview');
 
   card.dataset.area = question.area;
   card.dataset.subject = question.subject;
@@ -129,6 +130,7 @@ function renderQuestion(question) {
   meta.textContent = `${question.area} · ${question.subject} · ${question.level}`;
   body.innerHTML = question.statementHtml;
   solution.innerHTML = question.solutionHtml;
+  moodlePreview.innerHTML = renderMoodlePreview(question);
 
   (question.tags || []).forEach((tag) => {
     const item = document.createElement('span');
@@ -138,6 +140,32 @@ function renderQuestion(question) {
   });
 
   return fragment;
+}
+
+function renderMoodlePreview(question) {
+  return `
+    <section class="moodle-card" aria-label="Preview estilo Moodle de ${escapeHtml(question.title)}">
+      <div class="moodle-toolbar">
+        <span class="moodle-pill">Simulação</span>
+        <span class="moodle-context">${escapeHtml(question.level)} · ${escapeHtml(question.subject)}</span>
+      </div>
+      <div class="moodle-question">
+        <div class="moodle-number" aria-hidden="true">Q</div>
+        <div class="moodle-content">
+          <p class="moodle-label">Enunciado da questão</p>
+          <div class="moodle-statement">${question.statementHtml}</div>
+        </div>
+      </div>
+      <div class="moodle-feedback">
+        <p class="moodle-label">Feedback / solução demonstrativa</p>
+        <div>${question.solutionHtml}</div>
+      </div>
+      <p class="moodle-note">
+        Esta é uma simulação visual para divulgação. Não é uma cópia exata da interface do Moodle
+        nem uma exportação XML avaliativa.
+      </p>
+    </section>
+  `;
 }
 
 function uniqueSorted(values) {

--- a/site/questoes.html
+++ b/site/questoes.html
@@ -87,6 +87,10 @@
           <summary>Ver solução demonstrativa</summary>
           <div class="solution-body"></div>
         </details>
+        <details>
+          <summary>Ver preview estilo Moodle</summary>
+          <div class="moodle-preview"></div>
+        </details>
       </article>
     </template>
 


### PR DESCRIPTION
## Resumo

Este PR adiciona ao catálogo público uma visualização inspirada no Moodle para cada questão demonstrativa.

Resolve #42.

## O que foi incluído

- Nova seção expansível `Ver preview estilo Moodle` em cada card de questão.
- Renderização do preview pelo JavaScript do site.
- Layout com enunciado, alternativas e feedback/solução demonstrativa.
- Aviso explícito de que a visualização é uma simulação, não uma cópia exata do Moodle nem exportação XML avaliativa.
- Estilos responsivos para desktop e celular.

## Segurança avaliativa

O PR usa apenas os dados demonstrativos já carregados pelo catálogo público e continua dependendo do filtro `visibility = "demo"` e do gerador seguro criado em #51.

## Fora do escopo

- Exportação real de XML Moodle.
- Integração com uma instância Moodle.
- Reprodução exata da interface do Moodle.