### PR TITLE
Corrige exname duplicados no banco de questões

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"9213c9e3-a3d4-4e33-9fb1-81d6e4454340","pid":83764,"procStart":"18977000","acquiredAt":1780695398497}

--- a/BancoDeQuestoes/calorimetria/Q22TroCal.Rnw
+++ b/BancoDeQuestoes/calorimetria/Q22TroCal.Rnw
@@ -31,5 +31,5 @@ João misturou $\Sexpr{mass1}$ kg de água (calor específico sensível = $1,0$ 
 %% META-INFORMATION
 %% \extype{num}
 %% \exsolution{\Sexpr{resp1}}
-%% \exname{Q21TroCal}
+%% \exname{Q22TroCal}
 %% \extol{0.1}

--- a/BancoDeQuestoes/estatica/Q18estpm.Rnw
+++ b/BancoDeQuestoes/estatica/Q18estpm.Rnw
@@ -32,5 +32,5 @@ Determine o alongamento da mola, em $cm$ nesta nova situação. Caso necessário
 %% META-INFORMATION
 %% \extype{num}
 %% \exsolution{\Sexpr{resp}}
-%% \exname{Q17estpm}
+%% \exname{Q18estpm}
 %% \extol{0.1}

--- a/BancoDeQuestoes/hidrostatica/Q07LeiStevin2.Rnw
+++ b/BancoDeQuestoes/hidrostatica/Q07LeiStevin2.Rnw
@@ -76,5 +76,5 @@ Como $h = 0$ m então $\Delta P = 0$ Pa.
 %% \extype{cloze}
 %% \exsolution{\Sexpr{patm}|\Sexpr{delta_p}}
 %% \exclozetype{num|num}
-%% \exname{Q07LeiStevin}
+%% \exname{Q07LeiStevin2}
 %% \extol{0.001|0.01}

--- a/BancoDeQuestoes/hidrostatica/Q08Pressao.Rnw
+++ b/BancoDeQuestoes/hidrostatica/Q08Pressao.Rnw
@@ -35,5 +35,5 @@ A pressão será $\Sexpr{nota_cient(pSI)}$ Pa.
 %% META-INFORMATION
 %% \extype{num}
 %% \exsolution{\Sexpr{pSI}}
-%% \exname{Q07Pressao}
+%% \exname{Q08Pressao}
 %% \extol{0.01}

--- a/BancoDeQuestoes/leisdenewton/atrito/Q02Atrito.Rnw
+++ b/BancoDeQuestoes/leisdenewton/atrito/Q02Atrito.Rnw
@@ -84,5 +84,5 @@ Um bloco de $\Sexpr{m}$ kg é colocado sobre um plano inclinado que faz um ângu
 %% \extype{cloze}
 %% \exclozetype{string|num|num}
 %% \exsolution{\Sexpr{resp1}|\Sexpr{resp2}|\Sexpr{resp3}}
-%% \exname{Q01Atrito}
+%% \exname{Q02Atrito}
 %% \extol{0|0.1|0.01}

--- a/BancoDeQuestoes/nc_og/Q05OG.Rnw
+++ b/BancoDeQuestoes/nc_og/Q05OG.Rnw
@@ -57,4 +57,4 @@ options(OutDec=".")
 %% \extype{cloze}
 %% \exclozetype{string|num}
 %% \exsolution{\Sexpr{respa}|\Sexpr{respb}}
-%% \exname{Q06OG}
+%% \exname{Q05OG}

--- a/BancoDeQuestoes/qtdmov_impulso/Q02testQmov.Rnw
+++ b/BancoDeQuestoes/qtdmov_impulso/Q02testQmov.Rnw
@@ -48,5 +48,5 @@ answerlist(
 %% META-INFORMATION
 %% \extype{schoice}
 %% \exsolution{\Sexpr{mchoice2string(solutions, single = TRUE)}}
-%% \exname{Q2TestQmov}
+%% \exname{Q02testQmov}
 

--- a/BancoDeQuestoes/qtdmov_impulso/Q03testImpulso.Rnw
+++ b/BancoDeQuestoes/qtdmov_impulso/Q03testImpulso.Rnw
@@ -48,5 +48,5 @@ answerlist(
 %% META-INFORMATION
 %% \extype{schoice}
 %% \exsolution{\Sexpr{mchoice2string(solutions, single = TRUE)}}
-%% \exname{Q2TestQmov}
+%% \exname{Q03testImpulso}
 

--- a/BancoDeQuestoes/qtdmov_impulso/Q04testCol.Rnw
+++ b/BancoDeQuestoes/qtdmov_impulso/Q04testCol.Rnw
@@ -56,5 +56,5 @@ answerlist(
 %% META-INFORMATION
 %% \extype{schoice}
 %% \exsolution{\Sexpr{mchoice2string(solutions, single = TRUE)}}
-%% \exname{Q2TestQmov}
+%% \exname{Q04testCol}
 

--- a/BancoDeQuestoes/termodinamica/Q06QuizTermd.Rnw
+++ b/BancoDeQuestoes/termodinamica/Q06QuizTermd.Rnw
@@ -101,5 +101,5 @@ answerlist(
 %% META-INFORMATION
 %% \extype{mchoice}
 %% \exsolution{\Sexpr{mchoice2string(solutions[1:6])}}
-%% \exname{Q02QuizCal}
+%% \exname{Q06QuizTermd}
 

--- a/BancoDeQuestoes/trabalhopotencia/Q05Trab.Rnw
+++ b/BancoDeQuestoes/trabalhopotencia/Q05Trab.Rnw
@@ -41,5 +41,5 @@ resp2 <- round(P/(d/1800))
 %% \extype{cloze}
 %% \exclozetype{num|num}
 %% \exsolution{\Sexpr{resp1}|\Sexpr{resp2}}
-%% \exname{Q02Trab}
+%% \exname{Q05Trab}
 %% \extol{1|1}

--- a/BancoDeQuestoes/trabalhopotencia/Q19Trab.Rnw
+++ b/BancoDeQuestoes/trabalhopotencia/Q19Trab.Rnw
@@ -46,5 +46,5 @@ include_supplement("Q19Trab.png")
 %% META-INFORMATION
 %% \extype{num}
 %% \exsolution{\Sexpr{resp1}|\Sexpr{resp2}}
-%% \exname{Q14Trab}
+%% \exname{Q19Trab}
 %% \extol{0.1}


### PR DESCRIPTION
## Resumo

Auditoria do banco com `tools/validate_bank.R` revelou **12 questões com `\exname` duplicado** — criadas a partir de cópias sem atualizar o identificador. Como o `exams` usa o `\exname` como nome/ID da questão no Moodle, IDs repetidos fazem uma questão **sobrescrever a outra** na importação.

## Correções (`\exname` → nome do próprio arquivo)

| Arquivo | exname antigo | exname novo |
|---|---|---|
| qtdmov_impulso/Q02testQmov | Q2TestQmov | Q02testQmov |
| qtdmov_impulso/Q03testImpulso | Q2TestQmov | Q03testImpulso |
| qtdmov_impulso/Q04testCol | Q2TestQmov | Q04testCol |
| calorimetria/Q22TroCal | Q21TroCal | Q22TroCal |
| estatica/Q18estpm | Q17estpm | Q18estpm |
| trabalhopotencia/Q19Trab | Q14Trab | Q19Trab |
| trabalhopotencia/Q05Trab | Q02Trab | Q05Trab |
| hidrostatica/Q08Pressao | Q07Pressao | Q08Pressao |
| hidrostatica/Q07LeiStevin2 | Q07LeiStevin | Q07LeiStevin2 |
| nc_og/Q05OG | Q06OG | Q05OG |
| termodinamica/Q06QuizTermd | Q02QuizCal | Q06QuizTermd |
| leisdenewton/atrito/Q02Atrito | Q01Atrito | Q02Atrito |

## Validação

- `tools/validate_bank.R`: os 12 `duplicate_question_id` desaparecem após a correção.
- Recompilei os 12 arquivos para **XML** (exams2moodle) e **PDF** (exams2pdf) localmente — todos OK.

## Fora do escopo (precisam de decisão)

Dois pares têm o **mesmo nome de arquivo em pastas diferentes**, então não dá para resolver só pelo nome — é preciso decidir qual renomear:
- `Q01MCU` → `cinematica/MCU/Q01MCU.Rnw` e `movcircular/Q01MCU.Rnw`
- `Q15MU` → `cinematica/MU/Q15MU.Rnw` e `trabalhopotencia/Q15MU.Rnw`

🤖 Generated with [Claude Code](https://claude.com/claude-code)