### PR TITLE
Corrige falsos positivos em validate_bank.R (meta indentada + answerlist estático)

### DIFF
--- a/tools/validate_bank.R
+++ b/tools/validate_bank.R
@@ -151,7 +151,13 @@ for (i in seq_along(files)) {
 
   if (!is.na(extype) && trimws(extype) %in% c("schoice", "mchoice") && !is.null(question)) {
     question_text <- paste(question, collapse = "\n")
-    if (!grepl("answerlist\\s*\\(", question_text)) {
+    # Aceita as duas formas válidas de listar alternativas no enunciado: a
+    # função answerlist(...) e o ambiente estático \begin{answerlist}. Antes
+    # só a forma de função era reconhecida, gerando falso positivo para
+    # questões com answerlist estático (ex.: hidrostatica/Q05Densidade).
+    has_answerlist <- grepl("answerlist\\s*\\(", question_text) ||
+      grepl("\\\\begin\\{answerlist\\}", question_text)
+    if (!has_answerlist) {
       add_problem(rel, "warning", "choice_question_without_answerlist")
     }
 

--- a/tools/validate_bank.R
+++ b/tools/validate_bank.R
@@ -63,7 +63,10 @@ extract_block <- function(txt, env) {
 }
 
 extract_meta <- function(txt, key) {
-  pattern <- paste0("^%%\\s*\\\\", key, "\\{(.*)\\}\\s*$")
+  # Permite indentação antes do "%%": vários .Rnw alinham a meta-informação
+  # com o restante do código (ex.: "  %% \\extype{cloze}"). O exams lê essas
+  # linhas normalmente; ancorar em "^%%" gerava falso positivo de meta ausente.
+  pattern <- paste0("^\\s*%%\\s*\\\\", key, "\\{(.*)\\}\\s*$")
   hits <- grep(pattern, txt, value = TRUE)
   if (length(hits) == 0) return(NA_character_)
   sub(pattern, "\\1", hits[1])


### PR DESCRIPTION
## Problema

`validate_bank.R` gerava falsos positivos em dois pontos por ser estrito demais com formatos que o `exams` aceita normalmente.

### 1. Meta-informação indentada

`extract_meta()` ancorava o padrão em `^%%`, exigindo que a meta começasse na coluna 0. Arquivos que indentam a meta junto ao código (ex.: `calortemp/Q15Term.Rnw`: `  %% \extype{cloze}`) eram reportados com `missing_extype`, `missing_exsolution` e `missing_exname_using_filename_as_id` — mesmo compilando e sendo avaliados normalmente.

**Correção:** aceitar espaços antes do `%%` (`^\s*%%`).

### 2. answerlist estático

A checagem `choice_question_without_answerlist` só procurava a forma de função `answerlist(...)` no enunciado, ignorando o ambiente estático `\begin{answerlist}` — também válido no `exams`. Isso gerava falso positivo (ex.: `hidrostatica/Q05Densidade`).

**Correção:** aceitar as duas formas (`answerlist(...)` **ou** `\begin{answerlist}`).

## Por que é seguro

Ambas as mudanças apenas **relaxam** as regras de detecção, então só podem reduzir falsos positivos — nunca criar novos achados.

## Validação

`tools/validate_bank.R` no banco atual:

| | erros | warnings |
|---|---|---|
| antes | 14 | 2 |
| depois | 12 | 0 |

Os 5 achados removidos eram todos falsos positivos (3 do `Q15Term` + warning de exname + warning de answerlist do `Q05Densidade`). Os 12 erros restantes são `duplicate_question_id` reais, cobertos por #53 e #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)