### PR TITLE
Add ENEM central mechanics questions

### DIFF
--- a/BancoDeQuestoes/cinematica/MU/Q90ClozeSensorTempoBloqueio.Rnw
+++ b/BancoDeQuestoes/cinematica/MU/Q90ClozeSensorTempoBloqueio.Rnw
@@ -1,0 +1,49 @@
+<<echo=FALSE, results=hide>>=
+## Inspirada no ENEM 2025 Q118.
+## Física central: movimento uniforme e tempo de bloqueio de sensor.
+
+L <- sample(c(0.10, 0.15, 0.20, 0.25, 0.30), 1)
+d <- sample(c(0.02, 0.03, 0.04, 0.05), 1)
+v <- sample(c(0.50, 0.75, 1.00, 1.25, 1.50), 1)
+dist <- L + d
+t <- dist / v
+fmt <- function(x, d = 2) formatC(x, format = "f", digits = d, decimal.mark = ",")
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Um objeto de comprimento $\Sexpr{fmt(L,2)}\,\mathrm{m}$ passa por um sensor óptico formado por um feixe de espessura efetiva $\Sexpr{fmt(d,2)}\,\mathrm{m}$. O objeto move-se com velocidade constante de $\Sexpr{fmt(v,2)}\,\mathrm{m/s}$.
+
+Durante quanto tempo o feixe fica bloqueado? Considere que o bloqueio começa quando a frente do objeto alcança o feixe e termina quando a traseira do objeto sai completamente dele.
+
+\end{question}
+
+\begin{solution}
+
+Para que o bloqueio termine, a frente do objeto deve percorrer o comprimento do objeto mais a espessura efetiva do feixe:
+\[
+\Delta s = L + d.
+\]
+Assim,
+\[
+\Delta s = \Sexpr{fmt(L,2)} + \Sexpr{fmt(d,2)} = \Sexpr{fmt(dist,2)}\,\mathrm{m}.
+\]
+Como o movimento é uniforme,
+\[
+t = \frac{\Delta s}{v}
+= \frac{\Sexpr{fmt(dist,2)}}{\Sexpr{fmt(v,2)}}
+= \Sexpr{fmt(t,2)}\,\mathrm{s}.
+\]
+
+Portanto, o feixe fica bloqueado por $\Sexpr{fmt(t,2)}\,\mathrm{s}$.
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{num}
+%% \exsolution{\Sexpr{round(t, 2)}}
+%% \extol{0.03}
+%% \exname{Q90ClozeSensorTempoBloqueio}
+%% \exsection{Mecanica; Cinematica; Movimento uniforme; ENEM}
+%% \exusepackage[utf8]{inputenc}

--- a/BancoDeQuestoes/cinematica/lancamentos/Q90ClozeLancamentoHorizontal.Rnw
+++ b/BancoDeQuestoes/cinematica/lancamentos/Q90ClozeLancamentoHorizontal.Rnw
@@ -1,0 +1,60 @@
+<<echo=FALSE, results=hide>>=
+## Inspirada em questões ENEM de lançamento horizontal.
+## Física central: queda livre e movimento uniforme horizontal.
+
+h <- sample(c(0.80, 1.25, 1.80, 2.45, 3.20), 1)
+g <- 10
+v <- sample(seq(2, 8, by = 0.5), 1)
+tqueda <- sqrt(2 * h / g)
+alcance <- v * tqueda
+fmt <- function(x, d = 2) formatC(x, format = "f", digits = d, decimal.mark = ",")
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Uma esfera abandona a borda de uma mesa horizontal com velocidade horizontal de módulo $\Sexpr{fmt(v,1)}\,\mathrm{m/s}$. A altura da mesa em relação ao chão é $\Sexpr{fmt(h,2)}\,\mathrm{m}$. Despreze a resistência do ar e adote $g = \Sexpr{g}\,\mathrm{m/s^2}$.
+
+Determine:
+
+\begin{answerlist}
+  \item o tempo de queda, em segundos;
+  \item a distância horizontal percorrida até atingir o chão, em metros.
+\end{answerlist}
+
+\end{question}
+
+\begin{solution}
+
+Na direção vertical, a esfera parte com velocidade vertical inicial nula. Assim,
+\[
+h = \frac{g t^2}{2}.
+\]
+Logo,
+\[
+t = \sqrt{\frac{2h}{g}} = \sqrt{\frac{2\cdot \Sexpr{fmt(h,2)}}{\Sexpr{g}}} = \Sexpr{fmt(tqueda,2)}\,\mathrm{s}.
+\]
+Na direção horizontal, o movimento é uniforme:
+\[
+x = v_x t.
+\]
+Portanto,
+\[
+x = \Sexpr{fmt(v,1)}\cdot \Sexpr{fmt(tqueda,2)} = \Sexpr{fmt(alcance,2)}\,\mathrm{m}.
+\]
+
+\begin{answerlist}
+  \item $\Sexpr{fmt(tqueda,2)}\,\mathrm{s}$
+  \item $\Sexpr{fmt(alcance,2)}\,\mathrm{m}$
+\end{answerlist}
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{cloze}
+%% \exsolution{\Sexpr{round(tqueda, 2)}|\Sexpr{round(alcance, 2)}}
+%% \exclozetype{num|num}
+%% \extol{0.03|0.03}
+%% \exname{Q90ClozeLancamentoHorizontal}
+%% \exsection{Mecanica; Cinematica; Lancamento horizontal; ENEM}
+%% \exusepackage[utf8]{inputenc}

--- a/BancoDeQuestoes/cinematica/lancamentos/Q91QuizLancamentoVerticalTopo.Rnw
+++ b/BancoDeQuestoes/cinematica/lancamentos/Q91QuizLancamentoVerticalTopo.Rnw
@@ -1,0 +1,61 @@
+<<echo=FALSE, results=hide>>=
+## Inspirada no ENEM 2023 Q100.
+## Física central: lançamento vertical no ponto mais alto.
+
+v0 <- sample(seq(10, 30, by = 5), 1)
+g <- 10
+tsubida <- v0 / g
+hmax <- v0^2 / (2 * g)
+correta <- "No ponto mais alto, a velocidade instantânea é nula e a aceleração continua apontando para baixo."
+alternativas <- c(
+  correta,
+  "No ponto mais alto, a velocidade e a aceleração são nulas.",
+  "No ponto mais alto, a velocidade é máxima e a aceleração é nula.",
+  "No ponto mais alto, a velocidade aponta para cima e a aceleração aponta para cima.",
+  "No ponto mais alto, a velocidade aponta para baixo e a aceleração é nula."
+)
+solutions <- alternativas == correta
+ordem <- sample(seq_along(alternativas))
+alternativas <- alternativas[ordem]
+solutions <- solutions[ordem]
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Uma bola é lançada verticalmente para cima com velocidade inicial $\Sexpr{v0}\,\mathrm{m/s}$. Despreze a resistência do ar e adote $g=\Sexpr{g}\,\mathrm{m/s^2}$.
+
+Qual afirmação descreve corretamente a velocidade e a aceleração da bola no ponto mais alto da trajetória?
+
+<<echo=FALSE, results=tex>>=
+answerlist(alternativas)
+@
+
+\end{question}
+
+\begin{solution}
+
+No ponto mais alto, a bola para instantaneamente antes de iniciar a descida. Portanto, sua velocidade instantânea é nula. Entretanto, a força gravitacional continua atuando e a aceleração permanece igual à aceleração da gravidade, orientada para baixo.
+
+Neste caso, o tempo de subida seria
+\[
+t = \frac{v_0}{g}=\frac{\Sexpr{v0}}{\Sexpr{g}}=\Sexpr{tsubida}\,\mathrm{s},
+\]
+e a altura máxima seria
+\[
+h = \frac{v_0^2}{2g}=\frac{\Sexpr{v0}^2}{2\cdot\Sexpr{g}}=\Sexpr{hmax}\,\mathrm{m}.
+\]
+Esses valores não mudam a conclusão conceitual sobre velocidade e aceleração no topo.
+
+<<echo=FALSE, results=tex>>=
+answerlist(ifelse(solutions, paste0("\\textbf{", alternativas, "}"), alternativas))
+@
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{schoice}
+%% \exsolution{\Sexpr{mchoice2string(solutions, single = TRUE)}}
+%% \exname{Q91QuizLancamentoVerticalTopo}
+%% \exsection{Mecanica; Cinematica; Lancamento vertical; ENEM}
+%% \exusepackage[utf8]{inputenc}

--- a/BancoDeQuestoes/leisdenewton/atrito/Q90QuizQuedaResistenciaAr.Rnw
+++ b/BancoDeQuestoes/leisdenewton/atrito/Q90QuizQuedaResistenciaAr.Rnw
@@ -1,0 +1,56 @@
+<<echo=FALSE, results=hide>>=
+## Inspirada no ENEM 2021 Q112.
+## Física central: queda livre e resistência do ar.
+
+obj1 <- sample(c("uma esfera metálica", "uma pedra pequena", "uma bolinha de vidro"), 1)
+obj2 <- sample(c("uma folha de papel aberta", "uma pena", "um pedaço de papel amassado"), 1)
+pergunta_vacuo <- sample(c(TRUE, FALSE), 1)
+if (pergunta_vacuo) {
+  contexto <- "em uma câmara de vácuo, na qual a resistência do ar pode ser desprezada"
+  correta <- "Os corpos têm a mesma aceleração, igual à aceleração da gravidade local."
+} else {
+  contexto <- "no ar, em uma situação na qual a resistência do ar não pode ser desprezada"
+  correta <- "A resistência do ar pode alterar o movimento, de modo que os corpos não precisam ter a mesma aceleração durante toda a queda."
+}
+alternativas <- c(
+  correta,
+  "O corpo de maior massa sempre cai com aceleração maior que a gravidade.",
+  "A aceleração da gravidade deixa de atuar sobre corpos leves.",
+  "No vácuo, corpos de massas diferentes ficam parados se forem soltos da mesma altura.",
+  "A resistência do ar aumenta necessariamente a aceleração de todos os corpos em queda."
+)
+solutions <- alternativas == correta
+ordem <- sample(seq_along(alternativas))
+alternativas <- alternativas[ordem]
+solutions <- solutions[ordem]
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Dois corpos, \Sexpr{obj1} e \Sexpr{obj2}, são abandonados da mesma altura \Sexpr{contexto}.
+
+Qual afirmação descreve corretamente a física da queda?
+
+<<echo=FALSE, results=tex>>=
+answerlist(alternativas)
+@
+
+\end{question}
+
+\begin{solution}
+
+Quando a resistência do ar é desprezível, todos os corpos próximos à superfície da Terra caem com a mesma aceleração gravitacional, independentemente da massa. Quando a resistência do ar não é desprezível, forças dissipativas dependentes da forma, da velocidade e da área exposta podem modificar o movimento.
+
+<<echo=FALSE, results=tex>>=
+answerlist(ifelse(solutions, paste0("\\textbf{", alternativas, "}"), alternativas))
+@
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{schoice}
+%% \exsolution{\Sexpr{mchoice2string(solutions, single = TRUE)}}
+%% \exname{Q90QuizQuedaResistenciaAr}
+%% \exsection{Mecanica; Queda livre; Resistencia do ar; ENEM}
+%% \exusepackage[utf8]{inputenc}

--- a/BancoDeQuestoes/qtdmov_impulso/Q90ClozeImpulsoColisao.Rnw
+++ b/BancoDeQuestoes/qtdmov_impulso/Q90ClozeImpulsoColisao.Rnw
@@ -1,0 +1,75 @@
+<<echo=FALSE, results=hide>>=
+## Inspirada em questões ENEM sobre segurança veicular e deformação.
+## Física central: impulso, quantidade de movimento e força média.
+
+m <- sample(seq(800, 1400, by = 100), 1)
+v_kmh <- sample(c(36, 54, 72), 1)
+v <- v_kmh / 3.6
+dt1 <- sample(c(0.05, 0.08, 0.10), 1)
+dt2 <- sample(c(0.20, 0.25, 0.30), 1)
+impulso <- m * v
+F1 <- impulso / dt1
+F2 <- impulso / dt2
+red <- F1 / F2
+fmt <- function(x, d = 2) formatC(x, format = "f", digits = d, decimal.mark = ",")
+nota <- function(x) formatC(x, format = "f", digits = 0, big.mark = ".", decimal.mark = ",")
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Um veículo de massa $\Sexpr{m}\,\mathrm{kg}$ move-se a $\Sexpr{v_kmh}\,\mathrm{km/h}$ e é parado em uma colisão frontal. Em uma estrutura rígida, o intervalo de parada seria $\Sexpr{fmt(dt1,2)}\,\mathrm{s}$. Com uma região deformável de absorção de impacto, o intervalo de parada passa a ser $\Sexpr{fmt(dt2,2)}\,\mathrm{s}$.
+
+Determine:
+
+\begin{answerlist}
+  \item o módulo do impulso necessário para parar o veículo, em $\mathrm{N\,s}$;
+  \item a força média na parada rígida, em N;
+  \item o fator pelo qual a força média diminui com a região deformável.
+\end{answerlist}
+
+\end{question}
+
+\begin{solution}
+
+A velocidade em unidades do SI é
+\[
+v = \frac{\Sexpr{v_kmh}}{3{,}6}=\Sexpr{fmt(v,1)}\,\mathrm{m/s}.
+\]
+O impulso necessário para parar o veículo tem módulo igual à variação da quantidade de movimento:
+\[
+I = \Delta p = mv = \Sexpr{m}\cdot\Sexpr{fmt(v,1)} = \Sexpr{nota(impulso)}\,\mathrm{N\,s}.
+\]
+A força média é
+\[
+F_m = \frac{I}{\Delta t}.
+\]
+Na parada rígida,
+\[
+F_1 = \frac{\Sexpr{nota(impulso)}}{\Sexpr{fmt(dt1,2)}} = \Sexpr{nota(F1)}\,\mathrm{N}.
+\]
+Com a região deformável,
+\[
+F_2 = \frac{\Sexpr{nota(impulso)}}{\Sexpr{fmt(dt2,2)}} = \Sexpr{nota(F2)}\,\mathrm{N}.
+\]
+Como o impulso é o mesmo, aumentar o tempo de parada reduz a força média. O fator de redução é
+\[
+\frac{F_1}{F_2}=\frac{\Delta t_2}{\Delta t_1}=\frac{\Sexpr{fmt(dt2,2)}}{\Sexpr{fmt(dt1,2)}}=\Sexpr{fmt(red,2)}.
+\]
+
+\begin{answerlist}
+  \item $\Sexpr{nota(impulso)}\,\mathrm{N\,s}$
+  \item $\Sexpr{nota(F1)}\,\mathrm{N}$
+  \item $\Sexpr{fmt(red,2)}$
+\end{answerlist}
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{cloze}
+%% \exsolution{\Sexpr{round(impulso, 0)}|\Sexpr{round(F1, 0)}|\Sexpr{round(red, 2)}}
+%% \exclozetype{num|num|num}
+%% \extol{10|100|0.02}
+%% \exname{Q90ClozeImpulsoColisao}
+%% \exsection{Mecanica; Impulso; Colisao; ENEM}
+%% \exusepackage[utf8]{inputenc}

--- a/BancoDeQuestoes/trabalhopotencia/Q90ClozePotenciaEnergiaCinetica.Rnw
+++ b/BancoDeQuestoes/trabalhopotencia/Q90ClozePotenciaEnergiaCinetica.Rnw
@@ -1,0 +1,72 @@
+<<echo=FALSE, results=hide>>=
+## Inspirada no ENEM 2021 Q104.
+## Física central: energia cinética e potência média.
+
+m <- sample(seq(800, 1400, by = 100), 1)
+v_kmh <- sample(c(72, 90, 108, 126), 1)
+v <- v_kmh / 3.6
+t1 <- sample(c(8, 10, 12), 1)
+t2 <- t1 + sample(c(4, 6, 8), 1)
+Ec <- 0.5 * m * v^2
+P1 <- Ec / t1
+P2 <- Ec / t2
+razao <- P1 / P2
+fmt <- function(x, d = 1) formatC(x, format = "f", digits = d, decimal.mark = ",")
+nota <- function(x) formatC(x, format = "f", digits = 0, big.mark = ".", decimal.mark = ",")
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Dois veículos de mesma massa, $\Sexpr{m}\,\mathrm{kg}$, partem do repouso e atingem a velocidade de $\Sexpr{v_kmh}\,\mathrm{km/h}$. O veículo A faz isso em $\Sexpr{t1}\,\mathrm{s}$, enquanto o veículo B faz isso em $\Sexpr{t2}\,\mathrm{s}$. Despreze perdas de energia.
+
+Determine:
+
+\begin{answerlist}
+  \item a energia cinética final de cada veículo, em joules;
+  \item a potência média do veículo A, em watts;
+  \item a razão entre a potência média de A e a potência média de B.
+\end{answerlist}
+
+\end{question}
+
+\begin{solution}
+
+A velocidade em unidades do SI é
+\[
+v = \frac{\Sexpr{v_kmh}}{3{,}6} = \Sexpr{fmt(v,1)}\,\mathrm{m/s}.
+\]
+A energia cinética final é
+\[
+E_c = \frac{mv^2}{2}
+= \frac{\Sexpr{m}\cdot (\Sexpr{fmt(v,1)})^2}{2}
+= \Sexpr{nota(Ec)}\,\mathrm{J}.
+\]
+A potência média é energia dividida pelo tempo:
+\[
+P_A = \frac{E_c}{t_A}
+= \frac{\Sexpr{nota(Ec)}}{\Sexpr{t1}}
+= \Sexpr{nota(P1)}\,\mathrm{W}.
+\]
+Como os dois veículos chegam à mesma energia cinética final,
+\[
+\frac{P_A}{P_B} = \frac{E_c/t_A}{E_c/t_B} = \frac{t_B}{t_A}
+= \frac{\Sexpr{t2}}{\Sexpr{t1}} = \Sexpr{fmt(razao,2)}.
+\]
+
+\begin{answerlist}
+  \item $\Sexpr{nota(Ec)}\,\mathrm{J}$
+  \item $\Sexpr{nota(P1)}\,\mathrm{W}$
+  \item $\Sexpr{fmt(razao,2)}$
+\end{answerlist}
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{cloze}
+%% \exsolution{\Sexpr{round(Ec, 0)}|\Sexpr{round(P1, 0)}|\Sexpr{round(razao, 2)}}
+%% \exclozetype{num|num|num}
+%% \extol{10|10|0.02}
+%% \exname{Q90ClozePotenciaEnergiaCinetica}
+%% \exsection{Mecanica; Energia; Potencia; ENEM}
+%% \exusepackage[utf8]{inputenc}


### PR DESCRIPTION
## Resumo

Adiciona o primeiro lote de questões de Mecânica da Física Central do ENEM, sem uso de imagens externas.

Este lote foi escolhido para reduzir risco técnico: são questões de cinemática, energia/potência, queda livre, impulso/colisão e tempo de bloqueio de sensor que podem ser usadas no Moodle sem depender de figuras originais do ENEM.

## Questões adicionadas

- `BancoDeQuestoes/cinematica/lancamentos/Q90ClozeLancamentoHorizontal.Rnw`
  - Lançamento horizontal
  - Tipo: `cloze`
  - Coleta: tempo de queda e alcance horizontal

- `BancoDeQuestoes/trabalhopotencia/Q90ClozePotenciaEnergiaCinetica.Rnw`
  - Energia cinética e potência média
  - Tipo: `cloze`
  - Coleta: energia cinética, potência média e razão entre potências

- `BancoDeQuestoes/leisdenewton/atrito/Q90QuizQuedaResistenciaAr.Rnw`
  - Queda livre com/sem resistência do ar
  - Tipo: `schoice`
  - Questão conceitual

- `BancoDeQuestoes/cinematica/lancamentos/Q91QuizLancamentoVerticalTopo.Rnw`
  - Lançamento vertical no ponto mais alto
  - Tipo: `schoice`
  - Questão conceitual com solucionário quantitativo auxiliar

- `BancoDeQuestoes/qtdmov_impulso/Q90ClozeImpulsoColisao.Rnw`
  - Impulso, colisão e redução da força média por aumento do tempo de parada
  - Tipo: `cloze`
  - Coleta: impulso, força média e fator de redução da força

- `BancoDeQuestoes/cinematica/MU/Q90ClozeSensorTempoBloqueio.Rnw`
  - Movimento uniforme e tempo de bloqueio de sensor
  - Tipo: `num`
  - Coleta: tempo de bloqueio

## Imagens

Este PR não adiciona imagens. As questões foram adaptadas para ficarem adequadas ao Moodle sem figuras externas.

As questões mecânicas que dependem de diagramas mais fortes ou imagens originais do ENEM ficarão para um PR separado, com triagem visual antes.

## Escopo técnico

- Não altera README.
- Não altera CircleCI.
- Não altera `docs/question-counts.csv` nem `docs/question-counts.svg`.
- Todas as questões incluem solucionário em LaTeX.
- A validação principal é o GitHub Actions, pois não há R disponível neste ambiente local.