### PR TITLE
Integra auditoria pedagógica ao CI

### DIFF
--- a/.github/workflows/r-tests.yml
+++ b/.github/workflows/r-tests.yml
@@ -70,6 +70,10 @@ jobs:
         run: |
           Rscript tools/quality_report.R --out-dir build/quality-report
 
+      - name: Generate teaching audit
+        run: |
+          Rscript tools/audit_teaching.R --out-dir build/quality-report
+
       - name: Upload quality report
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Resumo

Closes #60.

Este PR integra a auditoria pedagógica semiautomática ao workflow de R tests.

## O que muda

- Adiciona a etapa `Generate teaching audit` no workflow `.github/workflows/r-tests.yml`.
- A etapa executa:

```bash
Rscript tools/audit_teaching.R --out-dir build/quality-report
```

- O CSV `quality-teaching-audit.csv` passa a ser gerado dentro de `build/quality-report`.
- Como o upload do artefato já publica `build/quality-report`, o relatório pedagógico passa a sair junto no artefato `banco-fisica-quality-report`.

## Escopo

A auditoria continua diagnóstica: ela lista alertas e prioridades, mas não falha o CI pela quantidade de alertas encontrados.