### PR TITLE
[codex] Fix Shiny preview local images

### DIFF
--- a/app/R/parse_moodle_xml.R
+++ b/app/R/parse_moodle_xml.R
@@ -13,6 +13,25 @@ library(xml2)
          paste0("image/", ext))
 }
 
+.resolver_imagem_local <- function(nome, img_dir = NULL) {
+  candidatos <- character(0)
+  if (!is.null(img_dir)) {
+    candidatos <- c(candidatos, file.path(img_dir, nome))
+  }
+
+  root <- if (exists("ROOT", inherits = TRUE)) get("ROOT", inherits = TRUE) else getwd()
+  banco <- file.path(root, "BancoDeQuestoes")
+  if (dir.exists(banco)) {
+    achados <- list.files(banco, recursive = TRUE, full.names = TRUE)
+    achados <- achados[basename(achados) == nome]
+    candidatos <- c(candidatos, achados)
+  }
+
+  candidatos <- candidatos[file.exists(candidatos)]
+  if (length(candidatos) == 0) return(NA_character_)
+  candidatos[1]
+}
+
 .embutir_imagens <- function(html, qnode, img_dir = NULL) {
   ## 1) supplements embutidos no próprio XML (<file> base64 + @@PLUGINFILE@@)
   arquivos <- xml_find_all(qnode, ".//file")
@@ -35,11 +54,10 @@ library(xml2)
     if (grepl("^(data:|https?:)", val)) next
     nome <- basename(trimws(gsub("[{}]", "", val)))
     novo <- nome
-    if (!is.null(img_dir)) {
-      cam <- file.path(img_dir, nome)
-      if (file.exists(cam))
-        novo <- paste0("data:", .mime_de(nome), ";base64,",
-                       base64enc::base64encode(cam))
+    cam <- .resolver_imagem_local(nome, img_dir)
+    if (!is.na(cam)) {
+      novo <- paste0("data:", .mime_de(nome), ";base64,",
+                     base64enc::base64encode(cam))
     }
     html <- gsub(s, paste0('src="', novo, '"'), html, fixed = TRUE)
   }


### PR DESCRIPTION
## Summary

Fixes missing local images in the Shiny Moodle preview app.

Some generated Moodle XML question HTML references images as local filenames such as `{Q04MCU.png}` instead of embedding them as Moodle `<file>` supplements. This was visible in MCU questions where the preview could not resolve those local image paths when loading XML without an explicit question directory.

## What changed

- Adds a local image resolver in `app/R/parse_moodle_xml.R`
- Keeps the existing `img_dir` lookup for compiled `.Rnw` previews
- Falls back to searching `BancoDeQuestoes` by image filename
- Embeds resolved local images as `data:image/...;base64` URIs before rendering

## Impact

MCU questions such as `Q02MCU`, `Q03MCU`, `Q04MCU`, `Q05MCU`, `Q07MCU`, `Q08MCU`, and `Q10MCU` now show their images in the Shiny app even when the XML contains unresolved local image references.

## Validation

- Compiled all MCU `.Rnw` questions that use `includegraphics` and parsed them through the Shiny XML parser
- Verified every parsed question contains a `data:image/...` source and no raw `src="Q..."` image path
- Simulated the Shiny runtime working directory (`app/`) and confirmed `Q08MCU` resolves to a `data:image/png;base64` URI