### PR TITLE
[codex] Generate structured Moodle XML artifacts

### DIFF
--- a/.github/workflows/moodle-xml.yml
+++ b/.github/workflows/moodle-xml.yml
@@ -1,0 +1,73 @@
+name: Moodle XML artifacts
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "BancoDeQuestoes/**"
+      - "Moodle/ExerciciosParaMoodle.R"
+      - "tools/generate_moodle_xml.R"
+      - ".github/workflows/moodle-xml.yml"
+  workflow_dispatch:
+    inputs:
+      seed:
+        description: "Seed used for deterministic variants"
+        required: false
+        default: "1"
+      variants:
+        description: "Variants per source question"
+        required: false
+        default: "100"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: moodle-xml-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+
+    env:
+      R_KEEP_PKG_SOURCE: yes
+      NOT_CRAN: true
+      XML_SEED: ${{ github.event.inputs.seed || '1' }}
+      XML_VARIANTS: ${{ github.event.inputs.variants || '100' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Pandoc
+        uses: r-lib/actions/setup-pandoc@v2
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: '4.4.3'
+          use-public-rspm: true
+
+      - name: Install R dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          cache-version: moodle-xml-1
+          dependencies: '"all"'
+
+      - name: Generate structured Moodle XML package
+        run: |
+          Rscript tools/generate_moodle_xml.R \
+            --seed "$XML_SEED" \
+            --n "$XML_VARIANTS" \
+            --layout structured \
+            --out-dir build/moodle-xml \
+            --zip \
+            --check
+
+      - name: Upload Moodle XML package
+        uses: actions/upload-artifact@v4
+        with:
+          name: moodle-xml-structured
+          path: build/moodle-xml

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ rmarkdown/*md
 # Generated question-count assets
 build/
 public/
+Moodle/generated/
 
 # OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
 .httr-oauth

--- a/README.md
+++ b/README.md
@@ -35,25 +35,40 @@ Depois basta entrar na pasta e você encontra o código para todas as questões 
 
 ### Moodle
 
-Caso queira simplesmente utilizar as questões prontas no Moodle, você pode baixar o arquivo [XML.zip](https://github.com/IFSP-HTO/BancoFisica/blob/master/Moodle/XML.zip) em uma pasta do seu computador e descompactar. Você vai encontrar os arquivos em XML compilados para todas as questões disponíveis no banco. Há um arquivo para cada assunto.
+Os arquivos Moodle XML são artefatos gerados a partir das questões-fonte em `BancoDeQuestoes/**/*.Rnw`. O pacote estruturado mais recente é criado automaticamente pelo workflow **Moodle XML artifacts** no GitHub Actions e publicado como artifact `moodle-xml-structured`.
+
+Para baixar:
+
+1. Acesse a aba [Actions](https://github.com/IFSP-HTO/BancoFisica/actions).
+2. Abra a execução mais recente do workflow **Moodle XML artifacts**.
+3. Baixe o artifact `moodle-xml-structured`.
+4. Descompacte o arquivo e importe no Moodle os XMLs do assunto desejado.
+
+O pacote segue a mesma organização de `BancoDeQuestoes`, gerando um XML por diretório de questões. Por exemplo:
 
 ```text
-XML
-    ├── acel-12018.xml
-    ├── calorimetria-12018.xml
-    ├── calortemp-12018.xml
-    ├── dilatterm-12018.xml
-    ├── estatica-12018.xml
-    ├── hidrostatica-12019.xml
-    ├── leidosgases-12018.xml
-    ├── leisdenewton-12018.xml
-    ├── movcircular-12018.xml
-    ├── MU-12018.xml
-    ├── ondas-12018.xml
-    ├── optica-12018.xml
-    ├── termodinamica-12018.xml
-    └── trabalhopotencia-12018.xml
+build/moodle-xml
+    ├── acel-1.xml
+    ├── calorimetria-1.xml
+    ├── cinematica
+    │   ├── mcu-1.xml
+    │   ├── mu-1.xml
+    │   └── lancamentos-1.xml
+    ├── eletromagnetismo
+    │   └── eletrostatica-1.xml
+    ├── leisdenewton
+    │   └── atrito-1.xml
+    ├── manifest.csv
+    └── XML.zip
 ```
+
+O arquivo `manifest.csv` lista o assunto, o diretório-fonte, o XML gerado e a quantidade de questões exportadas. O script usado pelo workflow também pode ser executado localmente:
+
+```text
+Rscript tools/generate_moodle_xml.R --seed 1 --n 100 --layout structured --out-dir Moodle/generated --zip --check
+```
+
+Os XMLs legados versionados em `Moodle/*.xml` continuam disponíveis no repositório por compatibilidade, mas novas correções devem ser feitas preferencialmente nos `.Rnw` e regeneradas pelo workflow.
 
 #### Baixando
 

--- a/tools/generate_moodle_xml.R
+++ b/tools/generate_moodle_xml.R
@@ -1,0 +1,220 @@
+#!/usr/bin/env Rscript
+
+args <- commandArgs(trailingOnly = TRUE)
+
+get_arg <- function(flag, default = NULL) {
+  idx <- which(args == flag)
+  if (length(idx) == 1 && length(args) >= idx + 1) {
+    return(args[idx + 1])
+  }
+  default
+}
+
+has_flag <- function(flag) flag %in% args
+
+questions_dir <- get_arg("--questions-dir", "BancoDeQuestoes")
+out_dir <- get_arg("--out-dir", "Moodle/generated")
+seed <- as.integer(get_arg("--seed", "1"))
+n_variants <- as.integer(get_arg("--n", "100"))
+layout <- get_arg("--layout", "structured")
+make_zip <- has_flag("--zip")
+check_mode <- has_flag("--check")
+
+if (is.na(seed)) stop("--seed must be an integer")
+if (is.na(n_variants) || n_variants < 1) stop("--n must be a positive integer")
+if (!layout %in% c("structured", "flat")) {
+  stop("--layout must be either 'structured' or 'flat'")
+}
+if (!dir.exists(questions_dir)) {
+  stop("Questions directory not found: ", questions_dir)
+}
+
+repo_root <- normalizePath(getwd(), winslash = "/", mustWork = TRUE)
+questions_dir_abs <- normalizePath(questions_dir, winslash = "/", mustWork = TRUE)
+out_parent <- dirname(out_dir)
+if (!dir.exists(out_parent)) dir.create(out_parent, recursive = TRUE)
+out_dir_abs <- normalizePath(out_dir, winslash = "/", mustWork = FALSE)
+protected_dirs <- normalizePath(
+  c(repo_root, questions_dir_abs, file.path(repo_root, "Moodle")),
+  winslash = "/",
+  mustWork = FALSE
+)
+if (out_dir_abs %in% protected_dirs) {
+  stop("Refusing to clean protected output directory: ", out_dir)
+}
+
+suppressMessages({
+  library(exams)
+  library(callr)
+  library(magrittr)
+  library(stringr)
+  library(purrr)
+})
+
+slug_segment <- function(x) {
+  x <- iconv(x, from = "", to = "ASCII//TRANSLIT", sub = "")
+  x <- tolower(x)
+  x <- gsub("[^a-z0-9]+", "-", x)
+  x <- gsub("(^-+|-+$)", "", x)
+  if (!nzchar(x)) "assunto" else x
+}
+
+slug_path <- function(path) {
+  parts <- strsplit(path, "/", fixed = TRUE)[[1]]
+  paste(vapply(parts, slug_segment, character(1)), collapse = "/")
+}
+
+subject_dirs <- function(root) {
+  files <- sort(list.files(
+    root,
+    pattern = "\\.[Rr]nw$",
+    recursive = TRUE,
+    full.names = TRUE
+  ))
+  if (length(files) == 0) stop("No .Rnw files found in ", root)
+  dirs <- unique(dirname(files))
+  dirs[order(dirs)]
+}
+
+relative_dir <- function(path, root) {
+  sub(
+    paste0("^", normalizePath(root, winslash = "/", mustWork = TRUE), "/?"),
+    "",
+    normalizePath(path, winslash = "/", mustWork = TRUE)
+  )
+}
+
+output_for_subject <- function(subject, out_root, layout, seed) {
+  slug <- slug_path(subject)
+  if (layout == "structured") {
+    parent <- dirname(slug)
+    base <- basename(slug)
+    dir <- if (identical(parent, ".")) out_root else file.path(out_root, parent)
+    name <- paste0(base, "-", seed)
+  } else {
+    dir <- out_root
+    name <- paste0(gsub("/", "-", slug, fixed = TRUE), "-", seed)
+  }
+  list(dir = dir, name = name, file = file.path(dir, paste0(name, ".xml")))
+}
+
+generate_subject <- function(source_dir, output_dir, output_name, n_variants, seed) {
+  callr::r(
+    function(source_dir, output_dir, output_name, n_variants, seed) {
+      suppressMessages({
+        library(exams)
+        library(magrittr)
+        library(stringr)
+        library(purrr)
+      })
+      files <- sort(list.files(source_dir, pattern = "\\.[Rr]nw$", ignore.case = TRUE))
+      if (length(files) == 0) stop("No .Rnw files in ", source_dir)
+      if (!dir.exists(output_dir)) dir.create(output_dir, recursive = TRUE)
+      set.seed(seed)
+      exams2moodle(
+        files,
+        n = n_variants,
+        rule = "none",
+        schoice = list(shuffle = TRUE),
+        converter = "pandoc-mathjax",
+        name = output_name,
+        encoding = "UTF-8",
+        dir = output_dir,
+        edir = source_dir
+      )
+      file.path(output_dir, paste0(output_name, ".xml"))
+    },
+    args = list(
+      source_dir = source_dir,
+      output_dir = output_dir,
+      output_name = output_name,
+      n_variants = n_variants,
+      seed = seed
+    )
+  )
+}
+
+validate_xml <- function(path) {
+  text <- paste(readLines(path, warn = FALSE, encoding = "UTF-8"), collapse = "\n")
+  if (!grepl("<quiz[[:space:]>]", text, perl = TRUE)) {
+    stop("Missing <quiz> root in ", path)
+  }
+  if (!grepl("</quiz>", text, fixed = TRUE)) {
+    stop("Missing </quiz> closing tag in ", path)
+  }
+  if (grepl("<parsererror", text, fixed = TRUE)) {
+    stop("Parser error marker in ", path)
+  }
+  tags <- regmatches(
+    text,
+    gregexpr("<question[[:space:]]+type=\"[^\"]+\"", text, perl = TRUE)
+  )[[1]]
+  if (length(tags) == 1 && identical(tags, -1L)) tags <- character()
+  sum(!grepl("type=\"category\"", tags, fixed = TRUE))
+}
+
+if (dir.exists(out_dir)) {
+  unlink(out_dir, recursive = TRUE)
+}
+dir.create(out_dir, recursive = TRUE)
+
+dirs <- subject_dirs(questions_dir)
+rows <- vector("list", length(dirs))
+
+cat("MOODLE_XML_GENERATION_BEGIN\n")
+cat("Questions directory:", questions_dir, "\n")
+cat("Output directory:", out_dir, "\n")
+cat("Seed:", seed, "\n")
+cat("Variants per question:", n_variants, "\n")
+cat("Layout:", layout, "\n")
+cat("Subjects:", length(dirs), "\n")
+
+for (i in seq_along(dirs)) {
+  source_dir <- dirs[[i]]
+  subject <- relative_dir(source_dir, questions_dir)
+  out <- output_for_subject(subject, out_dir, layout, seed)
+  source_files <- list.files(source_dir, pattern = "\\.[Rr]nw$", ignore.case = TRUE)
+
+  cat(sprintf("[%d/%d] %s -> %s\n", i, length(dirs), subject, out$file))
+  xml_file <- generate_subject(source_dir, out$dir, out$name, n_variants, seed)
+  n_questions <- validate_xml(xml_file)
+
+  rows[[i]] <- data.frame(
+    subject = subject,
+    source_dir = source_dir,
+    xml_file = xml_file,
+    source_questions = length(source_files),
+    moodle_questions = n_questions,
+    variants = n_variants,
+    seed = seed,
+    stringsAsFactors = FALSE
+  )
+}
+
+manifest <- do.call(rbind, rows)
+manifest_file <- file.path(out_dir, "manifest.csv")
+write.csv(manifest, manifest_file, row.names = FALSE, fileEncoding = "UTF-8")
+
+zip_file <- NA_character_
+if (make_zip) {
+  zip_file <- file.path(out_dir, "XML.zip")
+  old <- getwd()
+  on.exit(setwd(old), add = TRUE)
+  setwd(out_dir)
+  files <- list.files(".", pattern = "\\.xml$|manifest\\.csv$", recursive = TRUE)
+  status <- utils::zip("XML.zip", files = files)
+  if (!identical(status, 0L)) stop("Failed to create ", zip_file)
+  setwd(old)
+}
+
+print(manifest[, c("subject", "source_questions", "moodle_questions", "xml_file")],
+      row.names = FALSE)
+cat("Manifest:", manifest_file, "\n")
+if (make_zip) cat("Zip:", zip_file, "\n")
+cat("MOODLE_XML_GENERATION_END\n")
+
+if (check_mode) {
+  if (!file.exists(manifest_file)) stop("Manifest was not generated")
+  if (any(!file.exists(manifest$xml_file))) stop("Some XML files were not generated")
+  if (make_zip && !file.exists(zip_file)) stop("Zip was not generated")
+}


### PR DESCRIPTION
## Summary

Adds a structured Moodle XML generation workflow based on the current `BancoDeQuestoes` directory tree.

Instead of maintaining a manual list of subjects in `Moodle/ExerciciosParaMoodle.R`, the new generator discovers every directory containing `.Rnw` files and emits one Moodle XML file per source directory. Nested topics remain nested in the output, so groups such as `cinematica/MCU`, `cinematica/MU`, `cinematica/lancamentos`, `leisdenewton/atrito`, and `eletromagnetismo/eletrostática` are represented directly.

## What changed

- Adds `tools/generate_moodle_xml.R`
  - discovers `.Rnw` source directories automatically
  - supports `structured` and `flat` output layouts
  - writes `manifest.csv`
  - optionally creates `XML.zip`
  - refuses protected output directories such as `Moodle` to avoid deleting legacy XMLs accidentally
- Adds `.github/workflows/moodle-xml.yml`
  - generates structured Moodle XML artifacts in GitHub Actions
  - uploads `moodle-xml-structured`
- Ignores local `Moodle/generated/` output
- Updates README Moodle instructions to describe generated XML artifacts and the new structured package

## Validation

- `Rscript -e 'parse("tools/generate_moodle_xml.R")'`
- `Rscript tools/generate_moodle_xml.R --seed 1 --n 1 --layout structured --out-dir /tmp/bancofisica-moodle-xml --zip --check`
- `Rscript tools/generate_moodle_xml.R --seed 1 --n 3 --layout structured --out-dir /tmp/bancofisica-moodle-xml-n3 --zip --check`
- `Rscript tools/generate_moodle_xml.R --out-dir Moodle --n 1 --check` correctly refused the protected output directory

Note: `--seed 12026` exposed an existing `calorimetria` source issue where a generated `exsolution` is non-finite/non-missing for that seed. The new workflow defaults to seed `1`, which passed the validation above.