### PR TITLE
Add ENEM mechanics 2A questions

### DIFF
--- a/BancoDeQuestoes/cinematica/MCU/Q91ClozeBalancoTensao.Rnw
+++ b/BancoDeQuestoes/cinematica/MCU/Q91ClozeBalancoTensao.Rnw
@@ -1,0 +1,66 @@
+<<echo=FALSE, results=hide>>=
+## Inspirada no ENEM 2022 Q91
+## Física central: movimento circular, energia e tensão em duas cordas.
+
+m <- sample(c(16, 20, 24, 28, 32), 1)
+g <- 10
+T_total <- 3 * m * g
+T_corda <- T_total / 2
+T_ruptura <- 1.25 * T_corda
+fmt <- function(x, d = 1) formatC(x, format = "f", digits = d, decimal.mark = ",")
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Um balanço é construído com dois segmentos paralelos e iguais de uma mesma corda, sustentando uma tábua. Para dimensionar a corda, considera-se a situação em que uma criança de massa $\Sexpr{m}\,\mathrm{kg}$ passa pelo ponto mais baixo da trajetória. O balanço é solto de uma posição em que as cordas fazem ângulo de $90^\circ$ com a vertical. Despreze forças dissipativas e adote $g=\Sexpr{g}\,\mathrm{m/s^2}$.
+
+Por segurança, a tensão de ruptura de cada segmento de corda deve ser $25\%$ maior que a tensão máxima calculada em cada corda. Qual deve ser a tensão de ruptura mínima de cada segmento de corda, em newtons?
+
+\end{question}
+
+\begin{solution}
+
+Ao sair da posição horizontal e chegar ao ponto mais baixo, a criança desce uma altura igual ao comprimento $L$ das cordas. Pela conservação de energia,
+\[
+mgL = \frac{mv^2}{2}.
+\]
+Logo,
+\[
+v^2 = 2gL.
+\]
+No ponto mais baixo, a resultante radial é centrípeta. Como existem duas cordas, a soma das tensões nos dois segmentos deve satisfazer
+\[
+2T - mg = \frac{mv^2}{L}.
+\]
+Substituindo $v^2=2gL$,
+\[
+2T - mg = 2mg,
+\]
+\[
+2T = 3mg.
+\]
+Assim, a tensão em cada corda é
+\[
+T = \frac{3mg}{2}.
+\]
+Para $m=\Sexpr{m}\,\mathrm{kg}$ e $g=\Sexpr{g}\,\mathrm{m/s^2}$,
+\[
+T = \frac{3\cdot \Sexpr{m}\cdot \Sexpr{g}}{2}=\Sexpr{fmt(T_corda,1)}\,\mathrm{N}.
+\]
+Como a tensão de ruptura deve ser $25\%$ maior,
+\[
+T_{\mathrm{ruptura}} = 1{,}25T = 1{,}25\cdot\Sexpr{fmt(T_corda,1)}=\Sexpr{fmt(T_ruptura,1)}\,\mathrm{N}.
+\]
+
+Portanto, a tensão de ruptura mínima de cada segmento é $\Sexpr{fmt(T_ruptura,1)}\,\mathrm{N}$.
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{num}
+%% \exsolution{\Sexpr{round(T_ruptura, 1)}}
+%% \extol{0.1}
+%% \exname{Q91ClozeBalancoTensao}
+%% \exsection{Mecanica; Movimento circular; Tensao; ENEM}
+%% \exusepackage[utf8]{inputenc}

--- a/BancoDeQuestoes/cinematica/MU/Q91ClozeSemaforosMRU.Rnw
+++ b/BancoDeQuestoes/cinematica/MU/Q91ClozeSemaforosMRU.Rnw
@@ -1,0 +1,92 @@
+<<echo=FALSE, results=hide>>=
+## Inspirada no ENEM 2020 Q122
+## Física central: aceleração, MRU e sincronização de semáforos.
+
+a <- 2
+v_kmh <- 72
+v <- v_kmh / 3.6
+OA <- v^2 / (2 * a)
+tA <- v / a
+Delta_t <- sample(c(12, 15, 18, 20), 1)
+d <- v * Delta_t
+fmt <- function(x, d = 1) formatC(x, format = "f", digits = d, decimal.mark = ",")
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Um carro parte do repouso no ponto $O$ e acelera uniformemente até atingir $\Sexpr{v_kmh}\,\mathrm{km/h}$ exatamente ao passar pelo semáforo $A$. A partir desse ponto, mantém velocidade constante. Os semáforos $A$, $B$ e $C$ devem ser sincronizados de modo que, após passar por $A$, o carro leve sempre $\Sexpr{Delta_t}\,\mathrm{s}$ para chegar ao semáforo seguinte. Considere que $O$ está a $\Sexpr{fmt(OA,0)}\,\mathrm{m}$ de $A$.
+
+\begin{figure}[h!]
+\begin{center}
+<<fig=TRUE, height=3.4, width=7, echo=FALSE, eps=FALSE, results=hide>>=
+op <- par(mar = c(2.5, 1, 1, 1))
+plot(0, 0, type = 'n', xlim = c(-15, 3*d + 25), ylim = c(-1.2, 1.5), axes = FALSE, xlab = '', ylab = '')
+abline(h = 0, lwd = 2)
+pos <- c(0, OA, OA + d, OA + 2*d)
+lab <- c('O', 'A', 'B', 'C')
+points(pos, rep(0, 4), pch = 19, cex = 1.4)
+text(pos, rep(-0.25, 4), lab, cex = 1.2)
+for(i in 2:4) {
+  segments(pos[i], 0, pos[i], 0.8, lwd = 2)
+  rect(pos[i] - 4, 0.8, pos[i] + 4, 1.35, lwd = 2)
+  points(rep(pos[i], 3), c(0.92, 1.08, 1.24), pch = 1, cex = 0.8)
+}
+arrows(pos[1], -0.55, pos[2], -0.55, length = 0.08, code = 3)
+text(mean(pos[1:2]), -0.78, paste0(OA, ' m'), cex = 0.9)
+arrows(pos[2], -0.55, pos[3], -0.55, length = 0.08, code = 3)
+text(mean(pos[2:3]), -0.78, 'd', cex = 1.1)
+arrows(pos[3], -0.55, pos[4], -0.55, length = 0.08, code = 3)
+text(mean(pos[3:4]), -0.78, 'd', cex = 1.1)
+arrows(8, 0.35, 55, 0.35, length = 0.08, lwd = 2)
+text(30, 0.55, 'acelera', cex = 0.9)
+arrows(OA + 10, 0.35, OA + 90, 0.35, length = 0.08, lwd = 2)
+text(OA + 50, 0.55, 'velocidade constante', cex = 0.9)
+par(op)
+@
+\end{center}
+\end{figure}
+
+Determine:
+
+\begin{answerlist}
+  \item o tempo para o carro ir de $O$ até $A$, em segundos;
+  \item a distância $d$ entre semáforos consecutivos, em metros.
+\end{answerlist}
+
+\end{question}
+
+\begin{solution}
+
+A velocidade final, em unidades do Sistema Internacional, é
+\[
+v = \frac{\Sexpr{v_kmh}}{3{,}6}=\Sexpr{fmt(v,1)}\,\mathrm{m/s}.
+\]
+Na fase acelerada, como o carro parte do repouso,
+\[
+v = at.
+\]
+Logo,
+\[
+t_A = \frac{v}{a}=\frac{\Sexpr{fmt(v,1)}}{\Sexpr{a}}=\Sexpr{fmt(tA,1)}\,\mathrm{s}.
+\]
+Após passar por $A$, o movimento é uniforme. Se o intervalo entre semáforos deve ser $\Sexpr{Delta_t}\,\mathrm{s}$, então
+\[
+d = v\Delta t = \Sexpr{fmt(v,1)}\cdot \Sexpr{Delta_t}=\Sexpr{fmt(d,1)}\,\mathrm{m}.
+\]
+
+\begin{answerlist}
+  \item $\Sexpr{fmt(tA,1)}\,\mathrm{s}$
+  \item $\Sexpr{fmt(d,1)}\,\mathrm{m}$
+\end{answerlist}
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{cloze}
+%% \exsolution{\Sexpr{round(tA, 1)}|\Sexpr{round(d, 1)}}
+%% \exclozetype{num|num}
+%% \extol{0.05|0.1}
+%% \exname{Q91ClozeSemaforosMRU}
+%% \exsection{Mecanica; Movimento uniforme; Cinematica; ENEM}
+%% \exusepackage[utf8]{inputenc}

--- a/BancoDeQuestoes/cinematica/lancamentos/Q92ClozeLancamentoObliquoCanhao.Rnw
+++ b/BancoDeQuestoes/cinematica/lancamentos/Q92ClozeLancamentoObliquoCanhao.Rnw
@@ -1,0 +1,93 @@
+<<echo=FALSE, results=hide>>=
+## Inspirada no ENEM 2021 Q128
+## Física central: lançamento oblíquo.
+
+g <- 10
+dx <- sample(c(90, 120, 150), 1)
+dy <- sample(c(20, 25, 30), 1)
+theta <- 53
+sen <- 0.8
+cos <- 0.6
+tan <- sen / cos
+v0 <- sqrt(g * dx^2 / (2 * cos^2 * (dx * tan - dy)))
+vx <- v0 * cos
+vy <- v0 * sen
+t <- dx / vx
+fmt <- function(x, d = 1) formatC(x, format = "f", digits = d, decimal.mark = ",")
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Em um exercício de lançamento de projéteis, um objeto é lançado do ponto $B$ com ângulo de $\Sexpr{theta}^\circ$ em relação à horizontal. O alvo $A$ está a uma distância horizontal de $\Sexpr{dx}\,\mathrm{m}$ e a uma altura $\Sexpr{dy}\,\mathrm{m}$ acima do ponto de lançamento. Despreze a resistência do ar, adote $g=\Sexpr{g}\,\mathrm{m/s^2}$, $\sin \Sexpr{theta}^\circ=\Sexpr{fmt(sen,1)}$ e $\cos \Sexpr{theta}^\circ=\Sexpr{fmt(cos,1)}$.
+
+\begin{figure}[h!]
+\begin{center}
+<<fig=TRUE, height=4, width=6, echo=FALSE, eps=FALSE, results=hide>>=
+op <- par(mar = c(3, 3, 1, 1))
+plot(0, 0, type = 'n', xlim = c(-5, dx + 20), ylim = c(-5, max(dy + 25, 70)), xlab = 'distancia horizontal (m)', ylab = 'altura (m)', axes = TRUE)
+abline(h = 0, col = 'gray50')
+xs <- seq(0, dx, length.out = 100)
+ys <- xs * tan - g * xs^2 / (2 * v0^2 * cos^2)
+lines(xs, ys, lwd = 2)
+points(c(0, dx), c(0, dy), pch = 19, cex = 1.2)
+text(0, -3, 'B', cex = 1.1)
+text(dx, dy + 4, 'A', cex = 1.1)
+arrows(0, 0, 22 * cos, 22 * sen, length = 0.08, lwd = 2)
+text(18, 18, paste0(theta, ' graus'), cex = 0.9)
+arrows(0, -2, dx, -2, length = 0.08, code = 3)
+text(dx/2, -4.5, paste0(dx, ' m'), cex = 0.9)
+arrows(dx + 5, 0, dx + 5, dy, length = 0.08, code = 3)
+text(dx + 10, dy/2, paste0(dy, ' m'), cex = 0.9)
+par(op)
+@
+\end{center}
+\end{figure}
+
+Determine:
+
+\begin{answerlist}
+  \item o componente horizontal da velocidade inicial, em $\mathrm{m/s}$;
+  \item o módulo da velocidade inicial necessária para atingir o alvo, em $\mathrm{m/s}$.
+\end{answerlist}
+
+\end{question}
+
+\begin{solution}
+
+A equação da trajetória de um lançamento oblíquo pode ser escrita como
+\[
+y = x\tan\theta - \frac{g x^2}{2v_0^2\cos^2\theta}.
+\]
+No ponto do alvo, $x=\Sexpr{dx}\,\mathrm{m}$ e $y=\Sexpr{dy}\,\mathrm{m}$. Assim,
+\[
+\Sexpr{dy} = \Sexpr{dx}\cdot\frac{\Sexpr{fmt(sen,1)}}{\Sexpr{fmt(cos,1)}} - \frac{\Sexpr{g}\cdot \Sexpr{dx}^2}{2v_0^2\cdot(\Sexpr{fmt(cos,1)})^2}.
+\]
+Isolando $v_0$,
+\[
+v_0 = \sqrt{\frac{g x^2}{2\cos^2\theta\,(x\tan\theta-y)}}.
+\]
+Substituindo os valores,
+\[
+v_0 = \Sexpr{fmt(v0,1)}\,\mathrm{m/s}.
+\]
+O componente horizontal é
+\[
+v_x = v_0\cos\theta = \Sexpr{fmt(v0,1)}\cdot\Sexpr{fmt(cos,1)}=\Sexpr{fmt(vx,1)}\,\mathrm{m/s}.
+\]
+
+\begin{answerlist}
+  \item $\Sexpr{fmt(vx,1)}\,\mathrm{m/s}$
+  \item $\Sexpr{fmt(v0,1)}\,\mathrm{m/s}$
+\end{answerlist}
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{cloze}
+%% \exsolution{\Sexpr{round(vx, 1)}|\Sexpr{round(v0, 1)}}
+%% \exclozetype{num|num}
+%% \extol{0.1|0.1}
+%% \exname{Q92ClozeLancamentoObliquoCanhao}
+%% \exsection{Mecanica; Lancamento obliquo; ENEM}
+%% \exusepackage[utf8]{inputenc}

--- a/BancoDeQuestoes/cinematica/lancamentos/Q93ClozeJatoAguaHorizontal.Rnw
+++ b/BancoDeQuestoes/cinematica/lancamentos/Q93ClozeJatoAguaHorizontal.Rnw
@@ -1,0 +1,95 @@
+<<echo=FALSE, results=hide>>=
+## Inspirada no ENEM 2022 Q110
+## Física central: lançamento horizontal e lançamento vertical.
+
+g <- 10
+h <- sample(c(0.80, 1.25, 1.80, 2.45), 1)
+x <- sample(c(2.0, 2.5, 3.0, 3.5), 1)
+t <- sqrt(2 * h / g)
+v <- x / t
+H <- v^2 / (2 * g)
+fmt <- function(x, d = 2) formatC(x, format = "f", digits = d, decimal.mark = ",")
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Uma mangueira está inicialmente na horizontal, com a saída de água a $\Sexpr{fmt(h,2)}\,\mathrm{m}$ do solo. Nessas condições, o jato de água atinge o chão a uma distância horizontal de $\Sexpr{fmt(x,1)}\,\mathrm{m}$ da saída. Em seguida, mantendo a mesma velocidade de saída da água, a mangueira é apontada verticalmente para cima. Despreze a resistência do ar e adote $g=\Sexpr{g}\,\mathrm{m/s^2}$.
+
+\begin{figure}[h!]
+\begin{center}
+<<fig=TRUE, height=3.8, width=7, echo=FALSE, eps=FALSE, results=hide>>=
+op <- par(mfrow = c(1, 2), mar = c(3, 3, 2, 1))
+plot(0, 0, type = 'n', xlim = c(-0.2, x + 0.7), ylim = c(0, max(h + 0.5, H + 0.5)), xlab = 'distancia horizontal (m)', ylab = 'altura (m)', main = 'Mangueira horizontal')
+abline(h = 0, col = 'gray50')
+segments(0, 0, 0, h, lwd = 3)
+points(0, h, pch = 19)
+xs <- seq(0, x, length.out = 100)
+ys <- h - g * xs^2 / (2 * v^2)
+lines(xs, ys, lwd = 2)
+arrows(0, h, 0.6, h, length = 0.08, lwd = 2)
+arrows(0, -0.05, x, -0.05, length = 0.08, code = 3)
+text(x/2, 0.10, paste0(x, ' m'), cex = 0.9)
+arrows(-0.08, 0, -0.08, h, length = 0.08, code = 3)
+text(0.16, h/2, paste0(h, ' m'), cex = 0.9)
+plot(0, 0, type = 'n', xlim = c(-1, 1), ylim = c(0, H + 0.7), xlab = '', ylab = 'altura (m)', main = 'Mangueira vertical', axes = TRUE)
+abline(h = 0, col = 'gray50')
+segments(0, 0, 0, 0.35, lwd = 3)
+arrows(0, 0.35, 0, min(H, H + 0.2), length = 0.08, lwd = 2)
+arrows(0.25, 0, 0.25, H, length = 0.08, code = 3)
+text(0.45, H/2, 'H', cex = 1.2)
+points(0, H, pch = 19)
+par(op)
+@
+\end{center}
+\end{figure}
+
+Determine:
+
+\begin{answerlist}
+  \item o tempo de queda do jato na situação horizontal, em segundos;
+  \item a velocidade de saída da água, em $\mathrm{m/s}$;
+  \item a altura máxima $H$ atingida quando a mangueira é apontada verticalmente, em metros.
+\end{answerlist}
+
+\end{question}
+
+\begin{solution}
+
+Na situação horizontal, o movimento vertical é uma queda livre com velocidade vertical inicial nula:
+\[
+h = \frac{gt^2}{2}.
+\]
+Logo,
+\[
+t = \sqrt{\frac{2h}{g}} = \sqrt{\frac{2\cdot\Sexpr{fmt(h,2)}}{\Sexpr{g}}}=\Sexpr{fmt(t,2)}\,\mathrm{s}.
+\]
+Na horizontal, o movimento é uniforme:
+\[
+v = \frac{x}{t}=\frac{\Sexpr{fmt(x,1)}}{\Sexpr{fmt(t,2)}}=\Sexpr{fmt(v,2)}\,\mathrm{m/s}.
+\]
+Com a mangueira apontada para cima, a altura máxima é obtida de
+\[
+v^2 = 2gH.
+\]
+Portanto,
+\[
+H = \frac{v^2}{2g}=\frac{(\Sexpr{fmt(v,2)})^2}{2\cdot\Sexpr{g}}=\Sexpr{fmt(H,2)}\,\mathrm{m}.
+\]
+
+\begin{answerlist}
+  \item $\Sexpr{fmt(t,2)}\,\mathrm{s}$
+  \item $\Sexpr{fmt(v,2)}\,\mathrm{m/s}$
+  \item $\Sexpr{fmt(H,2)}\,\mathrm{m}$
+\end{answerlist}
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{cloze}
+%% \exsolution{\Sexpr{round(t, 2)}|\Sexpr{round(v, 2)}|\Sexpr{round(H, 2)}}
+%% \exclozetype{num|num|num}
+%% \extol{0.03|0.05|0.05}
+%% \exname{Q93ClozeJatoAguaHorizontal}
+%% \exsection{Mecanica; Lancamento horizontal; ENEM}
+%% \exusepackage[utf8]{inputenc}

--- a/BancoDeQuestoes/leisdenewton/atrito/Q91QuizAtritoPlanoInclinado.Rnw
+++ b/BancoDeQuestoes/leisdenewton/atrito/Q91QuizAtritoPlanoInclinado.Rnw
@@ -1,0 +1,110 @@
+<<echo=FALSE, results=hide>>=
+## Inspirada no ENEM 2025 Q103
+## Física central: atrito em piso horizontal e plano inclinado.
+
+m <- sample(c(20, 30, 40, 50), 1)
+mu <- sample(c(0.20, 0.25, 0.30), 1)
+g <- 10
+theta <- sample(c(30, 37, 45), 1)
+cos_theta <- round(cos(theta * pi / 180), 2)
+f_piso <- mu * m * g
+f_rampa <- mu * m * g * cos(theta * pi / 180)
+alternativas <- paste('Gráfico', LETTERS[1:5])
+solutions <- c(TRUE, FALSE, FALSE, FALSE, FALSE)
+fmt <- function(x, d = 1) formatC(x, format = "f", digits = d, decimal.mark = ",")
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Uma caixa é arrastada lentamente do primeiro piso para o segundo piso de uma construção, passando por um plano inclinado. A caixa permanece em movimento durante todo o percurso. Considere que o coeficiente de atrito entre a caixa e a superfície é o mesmo no piso horizontal e no plano inclinado.
+
+No piso horizontal, a força normal é $N=mg$. No plano inclinado, a força normal é menor e vale $N=mg\cos\theta$. Portanto, a força de atrito tem comportamento diferente nos trechos horizontais e no trecho inclinado.
+
+\begin{figure}[h!]
+\begin{center}
+<<fig=TRUE, height=6.2, width=6, echo=FALSE, eps=FALSE, results=hide>>=
+op <- par(mfrow = c(3, 2), mar = c(2.2, 2.8, 2.0, 0.8))
+# esquema do percurso
+plot(0, 0, type = 'n', xlim = c(0, 10), ylim = c(0, 4.5), axes = FALSE, xlab = '', ylab = '', main = 'Percurso da caixa')
+segments(0.8, 1, 3.3, 1, lwd = 2)
+segments(3.3, 1, 6.5, 3, lwd = 2)
+segments(6.5, 3, 9.2, 3, lwd = 2)
+rect(1.5, 1.05, 2.1, 1.55, lwd = 2)
+rect(4.6, 2.0, 5.2, 2.5, lwd = 2)
+rect(7.4, 3.05, 8.0, 3.55, lwd = 2)
+text(1.9, 0.55, '1o piso', cex = 0.8)
+text(4.8, 1.45, 'plano inclinado', cex = 0.8)
+text(7.7, 2.55, '2o piso', cex = 0.8)
+text(5, 4.15, 'mesma rugosidade', cex = 0.9)
+# funcao auxiliar para graficos
+painel <- function(letra, y) {
+  plot(0, 0, type = 'n', xlim = c(0, 3), ylim = c(0, 1.3), axes = FALSE, xlab = '', ylab = '', main = paste('Grafico', letra))
+  arrows(0.2, 0.15, 2.8, 0.15, length = 0.07, lwd = 1.5)
+  arrows(0.2, 0.15, 0.2, 1.15, length = 0.07, lwd = 1.5)
+  text(2.55, 0.02, 'tempo', cex = 0.75)
+  text(0.02, 0.95, 'atrito', cex = 0.75, srt = 90)
+  lines(c(0.35, 1.2, 1.7, 2.55), y, lwd = 3)
+}
+painel('A', c(1.0, 0.55, 1.0, 1.0))
+painel('B', c(0.55, 1.0, 0.55, 0.55))
+painel('C', c(0.8, 0.8, 0.8, 0.8))
+painel('D', c(1.0, 1.0, 0.55, 0.25))
+painel('E', c(0.35, 1.0, 0.75, 0.35))
+par(op)
+@
+\end{center}
+\end{figure}
+
+Qual gráfico representa melhor a intensidade da força de atrito sobre a caixa ao longo do tempo?
+
+<<echo=FALSE, results=tex>>=
+answerlist(alternativas)
+@
+
+\end{question}
+
+\begin{solution}
+
+A força de atrito cinético tem módulo
+\[
+f = \mu N.
+\]
+Nos pisos horizontais,
+\[
+N = mg.
+\]
+Logo,
+\[
+f_{\mathrm{piso}} = \mu mg.
+\]
+Com os valores sorteados,
+\[
+f_{\mathrm{piso}} = \Sexpr{fmt(mu,2)}\cdot\Sexpr{m}\cdot\Sexpr{g}=\Sexpr{fmt(f_piso,1)}\,\mathrm{N}.
+\]
+No plano inclinado, a normal é menor:
+\[
+N = mg\cos\theta.
+\]
+Assim,
+\[
+f_{\mathrm{rampa}} = \mu mg\cos\theta.
+\]
+Como $\cos\theta<1$, a força de atrito no plano inclinado é menor que nos trechos horizontais:
+\[
+f_{\mathrm{rampa}} = \Sexpr{fmt(mu,2)}\cdot\Sexpr{m}\cdot\Sexpr{g}\cdot\Sexpr{fmt(cos_theta,2)}\approx\Sexpr{fmt(f_rampa,1)}\,\mathrm{N}.
+\]
+Portanto, o gráfico deve começar em um valor maior no primeiro piso, diminuir durante o plano inclinado e voltar ao valor maior no segundo piso.
+
+<<echo=FALSE, results=tex>>=
+answerlist(ifelse(solutions, paste0('\\textbf{', alternativas, '}'), alternativas))
+@
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{schoice}
+%% \exsolution{\Sexpr{mchoice2string(solutions, single = TRUE)}}
+%% \exname{Q91QuizAtritoPlanoInclinado}
+%% \exsection{Mecanica; Atrito; Plano inclinado; ENEM}
+%% \exusepackage[utf8]{inputenc}


### PR DESCRIPTION
## Resumo

Adiciona o lote **Mecânica 2A** das questões centrais do ENEM, conforme a triagem visual aprovada.

Este PR inclui apenas questões sem imagem externa: uma questão sem figura e quatro com figuras próprias geradas por chunks R dentro do próprio `.Rnw`. Isso evita anexos PNG neste lote e reduz risco na geração XML/PDF.

## Questões adicionadas

- `BancoDeQuestoes/cinematica/MCU/Q91ClozeBalancoTensao.Rnw`
  - ENEM 2022 Q91
  - Balanço, movimento circular e tensão em duas cordas
  - Tipo: `num`
  - Decisão visual: sem imagem

- `BancoDeQuestoes/cinematica/MU/Q91ClozeSemaforosMRU.Rnw`
  - ENEM 2020 Q122
  - Aceleração inicial, movimento uniforme e sincronização de semáforos
  - Tipo: `cloze`
  - Decisão visual: figura própria gerada por R

- `BancoDeQuestoes/cinematica/lancamentos/Q92ClozeLancamentoObliquoCanhao.Rnw`
  - ENEM 2021 Q128
  - Lançamento oblíquo
  - Tipo: `cloze`
  - Decisão visual: figura própria gerada por R

- `BancoDeQuestoes/cinematica/lancamentos/Q93ClozeJatoAguaHorizontal.Rnw`
  - ENEM 2022 Q110
  - Jato de água, lançamento horizontal e lançamento vertical
  - Tipo: `cloze`
  - Decisão visual: figura própria gerada por R

- `BancoDeQuestoes/leisdenewton/atrito/Q91QuizAtritoPlanoInclinado.Rnw`
  - ENEM 2025 Q103
  - Atrito em plano inclinado e gráfico força de atrito versus tempo
  - Tipo: `schoice`
  - Decisão visual: figura própria gerada por R

## Escopo técnico

- Não adiciona imagens externas.
- Não altera README.
- Não altera CircleCI.
- Não altera `docs/question-counts.csv` nem `docs/question-counts.svg`.
- Todas as questões têm solucionário em LaTeX.
- As figuras próprias são produzidas por chunks `fig=TRUE`, seguindo padrão já usado no banco.

## Observação

As questões com imagem original do ENEM ficaram para o próximo PR, Mecânica 2B.