### PR TITLE
[codex] Tune Moodle XML artifact workflow

### DIFF
--- a/.github/workflows/moodle-xml.yml
+++ b/.github/workflows/moodle-xml.yml
@@ -35,7 +35,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
       NOT_CRAN: true
       XML_SEED: ${{ github.event.inputs.seed || '1' }}
-      XML_VARIANTS: ${{ github.event.inputs.variants || '100' }}
+      XML_VARIANTS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.variants || '1' }}
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Depois basta entrar na pasta e você encontra o código para todas as questões 
 
 ### Moodle
 
-Os arquivos Moodle XML são artefatos gerados a partir das questões-fonte em `BancoDeQuestoes/**/*.Rnw`. O pacote estruturado mais recente é criado automaticamente pelo workflow **Moodle XML artifacts** no GitHub Actions e publicado como artifact `moodle-xml-structured`.
+Os arquivos Moodle XML são artefatos gerados a partir das questões-fonte em `BancoDeQuestoes/**/*.Rnw`. O pacote estruturado mais recente é criado automaticamente pelo workflow **Moodle XML artifacts** no GitHub Actions e publicado como artifact `moodle-xml-structured`. Em pushes para `master`, o workflow gera 1 variante por questão para manter o artefato rápido; para gerar mais variantes, execute o workflow manualmente e ajuste o campo `variants`.
 
 Para baixar:
 


### PR DESCRIPTION
## Summary
- make automatic Moodle XML artifact generation use 1 variant per question on pushes to master
- keep the manual workflow input default at 100 variants for larger on-demand packages
- document the automatic/manual behavior in the README

## Why
The merged artifact workflow was using 100 variants per question on every master push. After the Q23 fix, the non-finite calorimetria failure is addressed, but the full automatic artifact job remains too heavy for routine pushes.

## Validation
- Rscript tools/generate_moodle_xml.R --seed 1 --n 1 --layout structured --out-dir /tmp/bancofisica-moodle-xml-ci-fast --zip --check
- Shiny parser check for generated MCU XML: 11 questions loaded, 7 data URI images, 0 local PNG src leftovers
- Q23 statistical check: 100000 draws, 0 non-finite responses