### PR TITLE
Aproximar preview demonstrativo da interface do Moodle

### DIFF
--- a/site/css/moodle-preview.css
+++ b/site/css/moodle-preview.css
@@ -1,0 +1,244 @@
+.moodle-attempt {
+  border-radius: 4px;
+  background: #f7f7f7;
+  box-shadow: none;
+}
+
+.moodle-attempt-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid #d6d6d6;
+  background: #ffffff;
+}
+
+.moodle-attempt-header h3 {
+  margin: 0.15rem 0 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.moodle-crumb {
+  color: #5f6368;
+  font-size: 0.82rem;
+}
+
+.moodle-attempt-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 230px;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.moodle-attempt-main,
+.moodle-navigation {
+  border: 1px solid #d6d6d6;
+  border-radius: 3px;
+  background: #ffffff;
+}
+
+.moodle-question-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #d6d6d6;
+  background: #f5f5f5;
+}
+
+.moodle-question-title,
+.moodle-question-state {
+  margin: 0;
+}
+
+.moodle-question-title {
+  font-weight: 700;
+}
+
+.moodle-question-state,
+.moodle-question-tools,
+.moodle-nav-status {
+  color: #5f6368;
+  font-size: 0.9rem;
+}
+
+.moodle-question-tools {
+  display: grid;
+  gap: 0.3rem;
+  justify-items: end;
+}
+
+.moodle-flag,
+.moodle-check,
+.moodle-next,
+.moodle-finish {
+  min-height: 36px;
+  border: 1px solid #8f959e;
+  border-radius: 3px;
+  padding: 0.35rem 0.7rem;
+  color: #1f2937;
+  background: #ffffff;
+  font: inherit;
+  font-weight: 600;
+}
+
+.moodle-flag {
+  border: 0;
+  padding: 0;
+  color: #0f6cbf;
+  background: transparent;
+  text-align: right;
+}
+
+.moodle-question-body {
+  display: grid;
+  grid-template-columns: 46px minmax(0, 1fr);
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.moodle-attempt .moodle-number {
+  width: 38px;
+  height: 38px;
+  border: 1px solid #d6d6d6;
+  border-radius: 3px;
+  color: #1f2937;
+  background: #f5f5f5;
+}
+
+.moodle-attempt .moodle-label {
+  margin-bottom: 0.6rem;
+  color: #343a40;
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.moodle-attempt .moodle-statement ol {
+  counter-reset: option;
+  display: grid;
+  gap: 0.6rem;
+  padding: 0;
+  list-style: none;
+}
+
+.moodle-attempt .moodle-statement li {
+  position: relative;
+  padding: 0.55rem 0.75rem 0.55rem 2.75rem;
+  border: 1px solid #d6d6d6;
+  border-radius: 3px;
+  background: #ffffff;
+}
+
+.moodle-attempt .moodle-statement li::before {
+  counter-increment: option;
+  content: counter(option, lower-alpha);
+  position: absolute;
+  top: 0.55rem;
+  left: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.35rem;
+  height: 1.35rem;
+  border: 2px solid #6b7280;
+  border-radius: 50%;
+  color: #374151;
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.moodle-actions-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+.moodle-check {
+  color: #ffffff;
+  border-color: #0f6cbf;
+  background: #0f6cbf;
+}
+
+.moodle-next,
+.moodle-finish {
+  background: #f8f9fa;
+}
+
+.moodle-attempt .moodle-feedback {
+  margin: 0 1rem 1rem 4.9rem;
+  border: 1px solid #d1e7dd;
+  border-left: 4px solid #198754;
+  border-radius: 3px;
+  background: #f0fff4;
+}
+
+.moodle-navigation {
+  padding: 1rem;
+  align-self: start;
+}
+
+.moodle-navigation h4 {
+  margin: 0 0 0.85rem;
+  font-size: 1rem;
+}
+
+.moodle-nav-grid {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.moodle-nav-item {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border: 1px solid #9ca3af;
+  border-radius: 3px;
+  background: #ffffff;
+  font-weight: 700;
+}
+
+.moodle-nav-item.current {
+  border-color: #0f6cbf;
+  color: #ffffff;
+  background: #0f6cbf;
+}
+
+.moodle-finish {
+  width: 100%;
+  margin-top: 0.75rem;
+}
+
+.moodle-attempt .moodle-note {
+  padding: 0 1rem 1rem;
+  color: #5f6368;
+  font-size: 0.88rem;
+}
+
+@media (max-width: 800px) {
+  .moodle-attempt-header,
+  .moodle-question-header {
+    flex-direction: column;
+  }
+
+  .moodle-question-tools {
+    justify-items: start;
+  }
+
+  .moodle-attempt-layout,
+  .moodle-question-body {
+    grid-template-columns: 1fr;
+  }
+
+  .moodle-attempt .moodle-feedback {
+    margin-left: 1rem;
+  }
+}

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -84,8 +84,8 @@ function render() {
     return;
   }
 
-  filtered.forEach((question) => {
-    elements.catalog.appendChild(renderQuestion(question));
+  filtered.forEach((question, index) => {
+    elements.catalog.appendChild(renderQuestion(question, index));
   });
 
   if (window.MathJax?.typesetPromise) {
@@ -112,7 +112,7 @@ function matchesFilters(question) {
   );
 }
 
-function renderQuestion(question) {
+function renderQuestion(question, index) {
   const fragment = elements.template.content.cloneNode(true);
   const card = fragment.querySelector('.question-card');
   const title = fragment.querySelector('h2');
@@ -130,7 +130,7 @@ function renderQuestion(question) {
   meta.textContent = `${question.area} · ${question.subject} · ${question.level}`;
   body.innerHTML = question.statementHtml;
   solution.innerHTML = question.solutionHtml;
-  moodlePreview.innerHTML = renderMoodlePreview(question);
+  moodlePreview.innerHTML = renderMoodlePreview(question, index);
 
   (question.tags || []).forEach((tag) => {
     const item = document.createElement('span');
@@ -142,27 +142,65 @@ function renderQuestion(question) {
   return fragment;
 }
 
-function renderMoodlePreview(question) {
+function renderMoodlePreview(question, index) {
+  const number = index + 1;
+
   return `
-    <section class="moodle-card" aria-label="Preview estilo Moodle de ${escapeHtml(question.title)}">
-      <div class="moodle-toolbar">
-        <span class="moodle-pill">Simulação</span>
-        <span class="moodle-context">${escapeHtml(question.level)} · ${escapeHtml(question.subject)}</span>
-      </div>
-      <div class="moodle-question">
-        <div class="moodle-number" aria-hidden="true">Q</div>
-        <div class="moodle-content">
-          <p class="moodle-label">Enunciado da questão</p>
-          <div class="moodle-statement">${question.statementHtml}</div>
+    <section class="moodle-card moodle-attempt" aria-label="Preview estilo Moodle de ${escapeHtml(question.title)}">
+      <div class="moodle-attempt-header">
+        <div>
+          <span class="moodle-crumb">Página inicial / BancoFisica / Questionário demonstrativo</span>
+          <h3>Pré-visualização da questão demonstrativa</h3>
         </div>
+        <span class="moodle-pill">Simulação visual</span>
       </div>
-      <div class="moodle-feedback">
-        <p class="moodle-label">Feedback / solução demonstrativa</p>
-        <div>${question.solutionHtml}</div>
+
+      <div class="moodle-attempt-layout">
+        <article class="moodle-attempt-main">
+          <header class="moodle-question-header">
+            <div>
+              <p class="moodle-question-title">Questão ${number}</p>
+              <p class="moodle-question-state">Ainda não respondida</p>
+            </div>
+            <div class="moodle-question-tools">
+              <span>Vale 1,00 ponto(s)</span>
+              <button class="moodle-flag" type="button" aria-label="Marcar questão demonstrativa">⚑ Marcar questão</button>
+            </div>
+          </header>
+
+          <div class="moodle-question-body">
+            <div class="moodle-number" aria-hidden="true">${number}</div>
+            <div class="moodle-content">
+              <p class="moodle-label">Texto da questão</p>
+              <div class="moodle-statement">${question.statementHtml}</div>
+              <div class="moodle-actions-row" aria-hidden="true">
+                <button class="moodle-check" type="button">Verificar</button>
+                <button class="moodle-next" type="button">Próxima página</button>
+              </div>
+            </div>
+          </div>
+
+          <div class="moodle-feedback">
+            <p class="moodle-label">Feedback</p>
+            <div>${question.solutionHtml}</div>
+          </div>
+        </article>
+
+        <aside class="moodle-navigation" aria-label="Navegação simulada do questionário">
+          <h4>Navegação do questionário</h4>
+          <div class="moodle-nav-grid">
+            <span class="moodle-nav-item current">${number}</span>
+            <span class="moodle-nav-item">2</span>
+            <span class="moodle-nav-item">3</span>
+          </div>
+          <p class="moodle-nav-status">Questão atual: ${escapeHtml(question.subject)}</p>
+          <button class="moodle-finish" type="button">Terminar tentativa...</button>
+        </aside>
       </div>
+
       <p class="moodle-note">
-        Esta é uma simulação visual para divulgação. Não é uma cópia exata da interface do Moodle
-        nem uma exportação XML avaliativa.
+        Esta é uma simulação visual inspirada em uma tentativa de quiz. Não é uma cópia exata da interface do Moodle,
+        não usa tema oficial e não exporta XML avaliativo.
       </p>
     </section>
   `;

--- a/site/questoes.html
+++ b/site/questoes.html
@@ -9,6 +9,7 @@
     />
     <title>Questões demonstrativas | BancoFisica</title>
     <link rel="stylesheet" href="css/style.css" />
+    <link rel="stylesheet" href="css/moodle-preview.css" />
     <script>
       window.MathJax = {
         tex: { inlineMath: [['\\(', '\\)'], ['$', '$']] },


### PR DESCRIPTION
Resolve #71.

## Resumo

Este PR refina o preview estilo Moodle das questões demonstrativas para lembrar mais uma tela de tentativa de quiz.

## O que foi incluído

- Estrutura visual de tentativa com cabeçalho, trilha, estado da questão e valor em pontos.
- Botão visual de marcar questão e ações simuladas como `Verificar`, `Próxima página` e `Terminar tentativa...`.
- Bloco lateral de navegação do questionário.
- Alternativas com aparência mais próxima de múltipla escolha em quiz.
- CSS separado em `site/css/moodle-preview.css` para isolar essa simulação.

## Segurança avaliativa

A mudança continua usando apenas dados demonstrativos e mantém aviso explícito de que a visualização é uma simulação, não uma cópia exata da interface do Moodle nem exportação XML avaliativa.