### PR TITLE
Add thermology questions without external images

### DIFF
--- a/BancoDeQuestoes/calorimetria/Q91ClozeMisturaAgua.Rnw
+++ b/BancoDeQuestoes/calorimetria/Q91ClozeMisturaAgua.Rnw
@@ -1,0 +1,74 @@
+<<echo=FALSE, results=hide>>=
+## Questão estilo ENEM: mistura de porções de água.
+
+m1 <- sample(c(100, 150, 200, 250), 1) # g
+T1 <- sample(c(70, 80, 90), 1)
+m2 <- sample(c(200, 300, 400, 500), 1) # g
+T2 <- sample(c(10, 15, 20, 25), 1)
+c <- 1 # cal/(g C)
+Tf <- (m1*T1 + m2*T2) / (m1 + m2)
+Q_quente <- m1 * c * (T1 - Tf)
+Q_fria <- m2 * c * (Tf - T2)
+fmt <- function(x, d = 1) formatC(x, format = "f", digits = d, decimal.mark = ",")
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Em um recipiente termicamente isolado, misturam-se $\Sexpr{m1}\,\mathrm{g}$ de água a $\Sexpr{T1}\,^{\circ}\mathrm{C}$ com $\Sexpr{m2}\,\mathrm{g}$ de água a $\Sexpr{T2}\,^{\circ}\mathrm{C}$. Considere que não há perdas de calor para o ambiente e que o calor específico da água é o mesmo nas duas porções.
+
+Determine:
+
+\begin{answerlist}
+  \item a temperatura final de equilíbrio, em $^{\circ}\mathrm{C}$;
+  \item o módulo da quantidade de calor cedida pela água mais quente, em calorias.
+\end{answerlist}
+
+\end{question}
+
+\begin{solution}
+
+Como o sistema é termicamente isolado, o calor cedido pela água quente é igual, em módulo, ao calor recebido pela água fria:
+\[
+Q_{\mathrm{quente}} + Q_{\mathrm{fria}} = 0.
+\]
+Usando $Q=mc\Delta T$,
+\[
+\Sexpr{m1}c(T_f-\Sexpr{T1}) + \Sexpr{m2}c(T_f-\Sexpr{T2}) = 0.
+\]
+Como o calor específico é o mesmo para as duas porções, ele pode ser cancelado:
+\[
+\Sexpr{m1}(T_f-\Sexpr{T1}) + \Sexpr{m2}(T_f-\Sexpr{T2}) = 0.
+\]
+Logo,
+\[
+T_f = \frac{\Sexpr{m1}\cdot\Sexpr{T1}+\Sexpr{m2}\cdot\Sexpr{T2}}{\Sexpr{m1}+\Sexpr{m2}}.
+\]
+Substituindo,
+\[
+T_f=\Sexpr{fmt(Tf,1)}\,^{\circ}\mathrm{C}.
+\]
+O módulo do calor cedido pela água quente é
+\[
+|Q_{\mathrm{quente}}|=m_1c(T_1-T_f).
+\]
+Assim,
+\[
+|Q_{\mathrm{quente}}|=\Sexpr{m1}\cdot 1\cdot (\Sexpr{T1}-\Sexpr{fmt(Tf,1)})=\Sexpr{fmt(Q_quente,1)}\,\mathrm{cal}.
+\]
+
+\begin{answerlist}
+  \item $\Sexpr{fmt(Tf,1)}\,^{\circ}\mathrm{C}$
+  \item $\Sexpr{fmt(Q_quente,1)}\,\mathrm{cal}$
+\end{answerlist}
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{cloze}
+%% \exsolution{\Sexpr{round(Tf, 1)}|\Sexpr{round(Q_quente, 1)}}
+%% \exclozetype{num|num}
+%% \extol{0.1|0.5}
+%% \exname{Q91ClozeMisturaAgua}
+%% \exsection{Termologia; Calorimetria; Troca de calor}
+%% \exusepackage[utf8]{inputenc}

--- a/BancoDeQuestoes/calorimetria/Q92ClozeMudancaFaseGelo.Rnw
+++ b/BancoDeQuestoes/calorimetria/Q92ClozeMudancaFaseGelo.Rnw
@@ -1,0 +1,69 @@
+<<echo=FALSE, results=hide>>=
+## Questão estilo ENEM: fusão do gelo e aquecimento da água obtida.
+
+m <- sample(c(50, 80, 100, 120, 150), 1) # g
+Tf <- sample(c(10, 15, 20, 25, 30), 1)
+Lf <- 80 # cal/g
+cagua <- 1 # cal/(g C)
+Qfusao <- m * Lf
+Qaquec <- m * cagua * Tf
+Qtotal <- Qfusao + Qaquec
+fmt <- function(x, d = 1) formatC(x, format = "f", digits = d, decimal.mark = ",")
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Uma amostra de gelo de massa $\Sexpr{m}\,\mathrm{g}$ encontra-se inicialmente a $0\,^{\circ}\mathrm{C}$. Ela recebe calor até se transformar completamente em água líquida a $\Sexpr{Tf}\,^{\circ}\mathrm{C}$. Considere o calor latente de fusão do gelo igual a $80\,\mathrm{cal/g}$ e o calor específico da água líquida igual a $1\,\mathrm{cal/(g\,^{\circ}C)}$.
+
+Determine:
+
+\begin{answerlist}
+  \item a quantidade de calor necessária para fundir todo o gelo, em calorias;
+  \item a quantidade total de calor recebida pela amostra, em calorias.
+\end{answerlist}
+
+\end{question}
+
+\begin{solution}
+
+O processo ocorre em duas etapas. Primeiro, o gelo a $0\,^{\circ}\mathrm{C}$ funde, sem variação de temperatura. O calor necessário para a fusão é
+\[
+Q_{\mathrm{fusao}} = mL_f.
+\]
+Substituindo os valores,
+\[
+Q_{\mathrm{fusao}} = \Sexpr{m}\cdot 80 = \Sexpr{fmt(Qfusao,0)}\,\mathrm{cal}.
+\]
+Depois da fusão, a água líquida é aquecida de $0\,^{\circ}\mathrm{C}$ até $\Sexpr{Tf}\,^{\circ}\mathrm{C}$. Nessa etapa,
+\[
+Q_{\mathrm{aquec}} = mc\Delta T.
+\]
+Assim,
+\[
+Q_{\mathrm{aquec}} = \Sexpr{m}\cdot 1\cdot \Sexpr{Tf}=\Sexpr{fmt(Qaquec,0)}\,\mathrm{cal}.
+\]
+A quantidade total de calor é a soma das duas parcelas:
+\[
+Q_{\mathrm{total}} = Q_{\mathrm{fusao}} + Q_{\mathrm{aquec}}.
+\]
+Logo,
+\[
+Q_{\mathrm{total}} = \Sexpr{fmt(Qfusao,0)}+\Sexpr{fmt(Qaquec,0)}=\Sexpr{fmt(Qtotal,0)}\,\mathrm{cal}.
+\]
+
+\begin{answerlist}
+  \item $\Sexpr{fmt(Qfusao,0)}\,\mathrm{cal}$
+  \item $\Sexpr{fmt(Qtotal,0)}\,\mathrm{cal}$
+\end{answerlist}
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{cloze}
+%% \exsolution{\Sexpr{round(Qfusao, 0)}|\Sexpr{round(Qtotal, 0)}}
+%% \exclozetype{num|num}
+%% \extol{1|1}
+%% \exname{Q92ClozeMudancaFaseGelo}
+%% \exsection{Termologia; Calorimetria; Mudanca de fase}
+%% \exusepackage[utf8]{inputenc}

--- a/BancoDeQuestoes/calortemp/Q91ClozeAquecimentoAguaPotencia.Rnw
+++ b/BancoDeQuestoes/calortemp/Q91ClozeAquecimentoAguaPotencia.Rnw
@@ -1,0 +1,70 @@
+<<echo=FALSE, results=hide>>=
+## Questão estilo ENEM: aquecimento de água por potência térmica.
+
+m <- sample(c(0.5, 0.8, 1.0, 1.2, 1.5), 1) # kg
+Ti <- sample(c(20, 22, 25), 1)
+Tf <- sample(c(80, 90, 100), 1)
+P <- sample(c(500, 700, 900, 1000, 1200), 1) # W
+c <- 4200 # J/(kg C)
+Q <- m * c * (Tf - Ti)
+t <- Q / P
+t_min <- t / 60
+fmt <- function(x, d = 1) formatC(x, format = "f", digits = d, decimal.mark = ",")
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Um aquecedor elétrico de potência $\Sexpr{P}\,\mathrm{W}$ é usado para aquecer $\Sexpr{fmt(m,1)}\,\mathrm{kg}$ de água, inicialmente a $\Sexpr{Ti}\,^{\circ}\mathrm{C}$, até a temperatura de $\Sexpr{Tf}\,^{\circ}\mathrm{C}$. Considere que toda a energia elétrica fornecida pelo aquecedor seja transferida para a água e adote o calor específico da água igual a $4200\,\mathrm{J/(kg\,^{\circ}C)}$.
+
+Determine:
+
+\begin{answerlist}
+  \item a quantidade de calor absorvida pela água, em joules;
+  \item o tempo necessário para o aquecimento, em minutos.
+\end{answerlist}
+
+\end{question}
+
+\begin{solution}
+
+A quantidade de calor sensível trocada pela água é
+\[
+Q = mc\Delta T.
+\]
+A variação de temperatura é
+\[
+\Delta T = \Sexpr{Tf}-\Sexpr{Ti}=\Sexpr{Tf-Ti}\,^{\circ}\mathrm{C}.
+\]
+Assim,
+\[
+Q = \Sexpr{fmt(m,1)}\cdot 4200\cdot \Sexpr{Tf-Ti}=\Sexpr{fmt(Q,0)}\,\mathrm{J}.
+\]
+Como a potência é energia por unidade de tempo,
+\[
+P = \frac{Q}{t}.
+\]
+Logo,
+\[
+t = \frac{Q}{P}=\frac{\Sexpr{fmt(Q,0)}}{\Sexpr{P}}=\Sexpr{fmt(t,1)}\,\mathrm{s}.
+\]
+Convertendo para minutos,
+\[
+t = \frac{\Sexpr{fmt(t,1)}}{60}=\Sexpr{fmt(t_min,1)}\,\mathrm{min}.
+\]
+
+\begin{answerlist}
+  \item $\Sexpr{fmt(Q,0)}\,\mathrm{J}$
+  \item $\Sexpr{fmt(t_min,1)}\,\mathrm{min}$
+\end{answerlist}
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{cloze}
+%% \exsolution{\Sexpr{round(Q, 0)}|\Sexpr{round(t_min, 1)}}
+%% \exclozetype{num|num}
+%% \extol{10|0.1}
+%% \exname{Q91ClozeAquecimentoAguaPotencia}
+%% \exsection{Termologia; Calor sensivel; Potencia termica}
+%% \exusepackage[utf8]{inputenc}

--- a/BancoDeQuestoes/calortemp/Q92QuizEscalasTemperatura.Rnw
+++ b/BancoDeQuestoes/calortemp/Q92QuizEscalasTemperatura.Rnw
@@ -1,0 +1,65 @@
+<<echo=FALSE, results=hide>>=
+## Questão estilo ENEM: relação linear entre escalas termométricas.
+
+T_c <- sample(c(20, 25, 30, 35, 40), 1)
+alpha <- sample(c(1.5, 2.0, 2.5), 1)
+beta <- sample(c(-10, 5, 15, 20), 1)
+T_x <- alpha * T_c + beta
+alternativas <- c(
+  paste0(formatC(T_x, format = "f", digits = 1, decimal.mark = ","), " graus X"),
+  paste0(formatC(alpha * (T_c + 10) + beta, format = "f", digits = 1, decimal.mark = ","), " graus X"),
+  paste0(formatC(alpha * T_c - beta, format = "f", digits = 1, decimal.mark = ","), " graus X"),
+  paste0(formatC(T_c + beta, format = "f", digits = 1, decimal.mark = ","), " graus X"),
+  paste0(formatC(T_x + 20, format = "f", digits = 1, decimal.mark = ","), " graus X")
+)
+solutions <- c(TRUE, FALSE, FALSE, FALSE, FALSE)
+ord <- sample(seq_along(alternativas))
+alternativas <- alternativas[ord]
+solutions <- solutions[ord]
+fmt <- function(x, d = 1) formatC(x, format = "f", digits = d, decimal.mark = ",")
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Uma escala termométrica hipotética $X$ é construída de modo que a relação entre a temperatura $T_X$, medida nessa escala, e a temperatura $T_C$, medida em graus Celsius, seja linear:
+\[
+T_X = \Sexpr{fmt(alpha,1)}T_C + \Sexpr{fmt(beta,1)}.
+\]
+
+Nessa escala, qual é a indicação correspondente a $\Sexpr{T_c}\,^{\circ}\mathrm{C}$?
+
+<<echo=FALSE, results=tex>>=
+answerlist(alternativas)
+@
+
+\end{question}
+
+\begin{solution}
+
+A relação entre as escalas é dada por
+\[
+T_X = \Sexpr{fmt(alpha,1)}T_C + \Sexpr{fmt(beta,1)}.
+\]
+Para $T_C=\Sexpr{T_c}\,^{\circ}\mathrm{C}$,
+\[
+T_X = \Sexpr{fmt(alpha,1)}\cdot\Sexpr{T_c}+\Sexpr{fmt(beta,1)}.
+\]
+Logo,
+\[
+T_X = \Sexpr{fmt(T_x,1)}.
+\]
+Portanto, a indicação na escala hipotética é $\Sexpr{fmt(T_x,1)}\,^{\circ}X$.
+
+<<echo=FALSE, results=tex>>=
+answerlist(ifelse(solutions, paste0('\\textbf{', alternativas, '}'), alternativas))
+@
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{schoice}
+%% \exsolution{\Sexpr{mchoice2string(solutions, single = TRUE)}}
+%% \exname{Q92QuizEscalasTemperatura}
+%% \exsection{Termologia; Temperatura; Escalas termometricas}
+%% \exusepackage[utf8]{inputenc}

--- a/BancoDeQuestoes/termodinamica/Q90ClozeMaquinaTermica.Rnw
+++ b/BancoDeQuestoes/termodinamica/Q90ClozeMaquinaTermica.Rnw
@@ -1,0 +1,65 @@
+<<echo=FALSE, results=hide>>=
+## Questão estilo ENEM: rendimento de máquina térmica.
+
+Qq <- sample(c(1200, 1500, 2000, 2500, 3000), 1) # J
+eta_percent <- sample(c(20, 25, 30, 35, 40), 1)
+eta <- eta_percent / 100
+W <- eta * Qq
+Qc <- Qq - W
+fmt <- function(x, d = 1) formatC(x, format = "f", digits = d, decimal.mark = ",")
+@
+\usepackage[utf8]{inputenc}
+
+\begin{question}
+
+Uma máquina térmica opera em ciclos, recebendo $\Sexpr{Qq}\,\mathrm{J}$ de uma fonte quente a cada ciclo. O rendimento da máquina é de $\Sexpr{eta_percent}\%$.
+
+Determine:
+
+\begin{answerlist}
+  \item o trabalho realizado pela máquina em cada ciclo, em joules;
+  \item a quantidade de calor rejeitada para a fonte fria em cada ciclo, em joules.
+\end{answerlist}
+
+\end{question}
+
+\begin{solution}
+
+O rendimento de uma máquina térmica é definido por
+\[
+\eta = \frac{W}{Q_q},
+\]
+em que $W$ é o trabalho realizado e $Q_q$ é o calor recebido da fonte quente.
+
+Como o rendimento é $\Sexpr{eta_percent}\%$,
+\[
+\eta = \frac{\Sexpr{eta_percent}}{100}=\Sexpr{fmt(eta,2)}.
+\]
+Logo,
+\[
+W = \eta Q_q = \Sexpr{fmt(eta,2)}\cdot\Sexpr{Qq}=\Sexpr{fmt(W,0)}\,\mathrm{J}.
+\]
+Pela conservação de energia em um ciclo,
+\[
+Q_q = W + Q_f,
+\]
+em que $Q_f$ é o calor rejeitado para a fonte fria. Portanto,
+\[
+Q_f = Q_q - W = \Sexpr{Qq}-\Sexpr{fmt(W,0)}=\Sexpr{fmt(Qc,0)}\,\mathrm{J}.
+\]
+
+\begin{answerlist}
+  \item $\Sexpr{fmt(W,0)}\,\mathrm{J}$
+  \item $\Sexpr{fmt(Qc,0)}\,\mathrm{J}$
+\end{answerlist}
+
+\end{solution}
+
+%% META-INFORMATION
+%% \extype{cloze}
+%% \exsolution{\Sexpr{round(W, 0)}|\Sexpr{round(Qc, 0)}}
+%% \exclozetype{num|num}
+%% \extol{1|1}
+%% \exname{Q90ClozeMaquinaTermica}
+%% \exsection{Termodinamica; Maquina termica; Rendimento}
+%% \exusepackage[utf8]{inputenc}


### PR DESCRIPTION
## Resumo

Adiciona um lote inicial de **Termologia/Termodinâmica** sem imagens externas, para avançar enquanto o lote Mecânica 2B, com imagens originais do ENEM, fica aguardando aplicação local.

## Questões adicionadas

- `BancoDeQuestoes/calortemp/Q91ClozeAquecimentoAguaPotencia.Rnw`
  - Calor sensível e potência térmica
  - Tipo: `cloze`

- `BancoDeQuestoes/calorimetria/Q91ClozeMisturaAgua.Rnw`
  - Troca de calor em mistura de água
  - Tipo: `cloze`

- `BancoDeQuestoes/calorimetria/Q92ClozeMudancaFaseGelo.Rnw`
  - Fusão do gelo e aquecimento da água líquida
  - Tipo: `cloze`

- `BancoDeQuestoes/termodinamica/Q90ClozeMaquinaTermica.Rnw`
  - Rendimento de máquina térmica
  - Tipo: `cloze`

- `BancoDeQuestoes/calortemp/Q92QuizEscalasTemperatura.Rnw`
  - Escala termométrica linear hipotética
  - Tipo: `schoice`

## Escopo técnico

- Não adiciona imagens externas.
- Não altera README.
- Não altera arquivos em `docs/`.
- Não altera workflows.
- Todas as questões são parametrizadas.
- Todas as questões têm solucionário em LaTeX.

## Observação

Este PR é independente do pacote `bancofisica_pr_mecanica_2b.zip`, que contém as questões de Mecânica com imagens originais.